### PR TITLE
设置nginx与上游哪吒面板grpc保持连接

### DIFF
--- a/docs/en_US/guide/q3.md
+++ b/docs/en_US/guide/q3.md
@@ -17,8 +17,14 @@ server {
     location / {
         grpc_read_timeout 300s;
         grpc_send_timeout 300s;
-        grpc_pass grpc://localhost:5555;
+        grpc_socket_keepalive on;
+        grpc_pass grpc://grpcservers;
     }
+}
+
+upstream grpcservers {
+    server localhost:5555;
+    keepalive 1024;
 }
 ```
 

--- a/docs/guide/q3.md
+++ b/docs/guide/q3.md
@@ -17,8 +17,14 @@ server {
     location / {
         grpc_read_timeout 300s;
         grpc_send_timeout 300s;
-        grpc_pass grpc://localhost:5555;
+        grpc_socket_keepalive on;
+        grpc_pass grpc://grpcservers;
     }
+}
+
+upstream grpcservers {
+    server localhost:5555;
+    keepalive 1024;
 }
 ```
 


### PR DESCRIPTION
在使用nginx反代grpc过程中，发现默认情况下nginx和面板的grpc没有保持长连接导致产生大量的TIME_WAIT连接。通过keepalive参数设置nginx与上游服务器（面板的grpc服务）最大空闲保活连接数，可以极大减少TIME_WAIT连接的产生。