### PR TITLE
User grpcwebproxy instead of nginx.

### DIFF
--- a/docs/case/case5.md
+++ b/docs/case/case5.md
@@ -38,7 +38,8 @@
 * 默认内置本机探针 --- 能很方便的监控自身服务器信息
 * 数据更安全 --- Argo 隧道使用TLS加密通信，可以将应用程序流量安全地传输到 Cloudflare 网络，提高了应用程序的安全性和可靠性。此外，Argo Tunnel也可以防止IP泄露和DDoS攻击等网络威胁
 
-<img width="1298" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/6535a060-2138-4c72-9ffa-1175dc6f5c25.png">
+<img width="1298" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/a1192434-fb60-4944-b6d0-de4235323e3d">
+
 
 ## Argo 认证的获取方式: json 或 token
 Argo 隧道认证方式有 json 和 token，使用两个方式其中之一
@@ -60,7 +61,7 @@ Argo 隧道认证方式有 json 和 token，使用两个方式其中之一
 <img width="1659" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/5aa4df19-f277-4582-8a4d-eef34a00085c">
 <img width="1470" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/ec06ec20-a68d-405c-b6de-cd4c52cbd8c0">
 <img width="1652" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/d0fba15c-f41b-4ee4-bea3-f0506d9b2d23">
-<img width="1670" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/2a28eab8-e434-4d06-85db-f2017b50f8de">
+<img width="1394" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/ab526fae-7a71-4a7c-9aee-a3bfe4774958">
 <img width="1671" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/c6bcc511-e2f9-4616-bcca-47e1a8a25313">
 <img width="1670" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/7fbe3ef7-fb43-4925-9478-89ee08e44941">
 
@@ -222,11 +223,16 @@ tar czvf dashboard.tar.gz /dashboard
 |   |   |-- config.yaml      # 哪吒面板的配置，如 Github OAuth2 / gRPC 域名 / 端口 / 是否启用 TLS 等信息
 |   |   `-- sqlite.db        # SQLite 数据库文件，记录着面板设置的所有 severs 和 cron 等信息
 |   |-- entrypoint.sh        # 主脚本，容器运行后执行
-|   |-- nezha-agent          # 哪吒客户端，用于监控本地 localhost
 |   |-- nezha.csr            # SSL/TLS 证书签名请求
 |   |-- nezha.key            # SSL/TLS 证书的私钥信息
 |   |-- nezha.pem            # SSL/TLS 隐私增强邮件
 |   `-- restore.sh           # 还原备份脚本
+|-- usr
+|   `-- local
+|       `-- bin
+|           |-- cloudflared  # Cloudflare Argo 隧道主程序
+|           |-- grpcwebproxy # gRPC 反代主程序
+|           `-- nezha-agent  # 哪吒客户端，用于监控本地 localhost
 |-- dbfile                   # 记录最新的还原或备份文件名
 `-- version                  # 记录当前的面板 app 版本
 ```
@@ -241,6 +247,8 @@ tar czvf dashboard.tar.gz /dashboard
 * 用 Cloudflare Tunnel 进行内网穿透: https://blog.outv.im/2021/cloudflared-tunnel/
 * 如何给 GitHub Actions 添加自己的 Runner 主机: https://cloud.tencent.com/developer/article/1756690
 * github self-hosted runner 添加与启动: https://blog.csdn.net/sinat_32188225/article/details/125978331
+* 如何从Docker镜像中导出文件: https://www.pkslow.com/archives/extract-files-from-docker-image
+* grpcwebproxy: https://github.com/improbable-eng/grpc-web/tree/master/go/grpcwebproxy
 
 
 ## 免责声明:

--- a/docs/en_US/case/case5.md
+++ b/docs/en_US/case/case5.md
@@ -38,7 +38,7 @@ Mirror backup (not live update): [Argo-Nezha-Service-Container](https://github.c
 * Default built-in local probes --- can easily monitor their own server information
 * More secure data --- Argo Tunnel uses TLS encrypted communication to securely transmit application traffic to the Cloudflare network, improving application security and reliability. In addition, Argo Tunnel protects against network threats such as IP leaks and DDoS attacks.
 
-<img width="1298" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/6535a060-2138-4c72-9ffa-1175dc6f5c25.png">
+<img width="1298" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/a1192434-fb60-4944-b6d0-de4235323e3d">
 
 
 ## How to get Argo authentication: json or token
@@ -61,9 +61,10 @@ The Argo Tunnel authentication methods are json and token, use one of the two me
 <img width="1652" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/89b2b758-e550-413d-aa3e-216d226da7f4">
 <img width="1463" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/9f77e26b-a25d-4ff0-8425-1085708e19c3">
 <img width="1652" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/d0fba15c-f41b-4ee4-bea3-f0506d9b2d23">
-<img width="1670" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/2a28eab8-e434-4d06-85db-f2017b50f8de">
+<img width="1394" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/ab526fae-7a71-4a7c-9aee-a3bfe4774958">
 <img width="1671" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/c6bcc511-e2f9-4616-bcca-47e1a8a25313">
 <img width="1670" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/7fbe3ef7-fb43-4925-9478-89ee08e44941">
+
 
 ## Prepare variables to be used
 * Visit the Cloudflare website, select the domain name you want to use, and turn on the `network` option to turn the `gRPC` switch on.
@@ -222,11 +223,16 @@ tar czvf dashboard.tar.gz /dashboard
 |   |   |-- config.yaml      # Configuration for the Nezha panel, e.g. Github OAuth2 / gRPC domain / port / TLS enabled or not.
 |   |   `-- sqlite.db        # SQLite database file that records all severs and cron settings for the panel.
 |   |-- entrypoint.sh        # The main script, which is executed after the container is run.
-|   |-- nezha-agent          # Nezha client, used to monitor the localhost.
 |   |-- nezha.csr            # SSL/TLS certificate signing request
 |   |-- nezha.key            # Private key information for SSL/TLS certificate.
 |   |-- nezha.pem            # SSL/TLS Privacy Enhancement Email
 |   `-- restore.sh           # Restore backup scripts
+|-- usr
+|   `-- local
+|       `-- bin
+|           |-- cloudflared  # Cloudflare Argo tunnel main program.
+|           |-- grpcwebproxy # gRPC reverse proxy main program.
+|           `-- nezha-agent  # Nezha client, used to monitor the localhost.
 |-- dbfile                   # Record the name of the latest restore or backup file
 `-- version                  # Record the current panel app version
 ```
@@ -241,6 +247,8 @@ tar czvf dashboard.tar.gz /dashboard
 * Intranet Penetration with Cloudflare Tunnel: https://blog.outv.im/2021/cloudflared-tunnel/
 * How to add your own Runner host to GitHub Actions: https://cloud.tencent.com/developer/article/1756690
 * github self-hosted runner addition and startup: https://blog.csdn.net/sinat_32188225/article/details/125978331
+* How to export a file from a Docker image: https://www.pkslow.com/archives/extract-files-from-docker-image
+* grpcwebproxy: https://github.com/improbable-eng/grpc-web/tree/master/go/grpcwebproxy
 
 
 ## Disclaimer


### PR DESCRIPTION
gRPCwebProxy 比nginx 和 caddy 都好用，又轻量又稳定，彻底解决反代gRPC时不稳定，导致会闪灰的问题。