### PR TITLE
增加非容器方案；增加通过 Github 触发备份数据功能。

### DIFF
--- a/docs/case/case5.md
+++ b/docs/case/case5.md
@@ -11,12 +11,14 @@
 # 目录
 
 - [项目特点](case5.md#项目特点)
-- [Argo 认证的获取方式: json 或 token](case5.md#argo-认证的获取方式-json-或-token)
 - [准备需要用的变量](case5.md#准备需要用的变量)
+- [Argo 认证的获取方式: json 或 token](case5.md#argo-认证的获取方式-json-或-token)
 - [PaaS 部署实例](case5.md#PaaS-部署实例)
-- [VPS 部署实例](case5.md#VPS-部署实例)
+- [VPS 部署方式 1 --- docker](case5.md#vps-部署方式-1-----docker)
+- [VPS 部署方式 2 --- 宿主机](case5.md#vps-部署方式-2-----宿主机)
 - [客户端接入](case5.md#客户端接入)
 - [SSH 接入](case5.md#ssh-接入)
+- [手动备份数据](case5.md#手动备份数据)
 - [自动还原备份](case5.md#自动还原备份)
 - [手动还原备份](case5.md#手动还原备份)
 - [完美搬家](case5.md#完美搬家)
@@ -27,7 +29,7 @@
 * * *
 
 ## 项目特点:
-* 适用范围更广 --- 只要能连通网络，就能安装哪吒服务端，如 Nas 虚拟机 , Container PaaS 等
+* 适用范围更广 --- 只要能连通网络，就能安装哪吒服务端，如 LXC, OpenVZ VPS，Nas 虚拟机 , Container PaaS 等
 * Argo 隧道突破需要公网入口的限制 --- 传统的哪吒需要有两个公网端口，一个用于面板的访问，另一个用于客户端上报数据，本项目借用 Cloudflare Argo 隧道，使用内网穿透的办法
 * IPv4 / v6 具备更高的灵活性 --- 传统哪吒需要处理服务端和客户端的 IPv4/v6 兼容性问题，还需要通过 warp 等工具来解决不对应的情况。然而，本项目可以完全不需要考虑这些问题，可以任意对接，更加方便和简便
 * 一条 Argo 隧道分流多个域名和协议 --- 建立一条内网穿透的 Argo 隧道，即可分流三个域名(hostname)和协议(protocal)，分别用于面板的访问(http)，客户端上报数据(tcp)和 ssh（可选）
@@ -38,32 +40,7 @@
 * 默认内置本机探针 --- 能很方便的监控自身服务器信息
 * 数据更安全 --- Argo 隧道使用TLS加密通信，可以将应用程序流量安全地传输到 Cloudflare 网络，提高了应用程序的安全性和可靠性。此外，Argo Tunnel也可以防止IP泄露和DDoS攻击等网络威胁
 
-<img width="1298" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/a1192434-fb60-4944-b6d0-de4235323e3d">
-
-
-## Argo 认证的获取方式: json 或 token
-Argo 隧道认证方式有 json 和 token，使用两个方式其中之一
-
-### (方式 1 - Josn):
-#### 通过 Cloudflare Json 生成网轻松获取 Argo 隧道 json 信息: https://fscarmen.cloudflare.now.cc
-
-<img width="893" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/5b734a9d-b4fd-40ca-b7e6-5a1732a53175">
-
-#### 到 Cloudflare 官网，在相应的域名 `DNS` 记录里加上客户端上报数据(tcp)和 ssh（可选）的域名，打开橙色云启用 CDN
-
-<img width="1651" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/d5efb33d-b2a3-484c-b058-346c3e229088">
-<img width="1618" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/c44b638f-9984-47a7-a342-166549f6092e">
-
-### (方式 2 - Token): 通过 Cloudflare 官网，手动生成 Argo 隧道 token 信息
-#### 到 cf 官网：https://dash.cloudflare.com/ ，进入 zero trust 里生成 token 隧道和信息。
-
-<img width="1672" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/0c467d8b-5fbc-4bde-ac8a-db70ed8798f0">
-<img width="1659" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/5aa4df19-f277-4582-8a4d-eef34a00085c">
-<img width="1470" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/ec06ec20-a68d-405c-b6de-cd4c52cbd8c0">
-<img width="1652" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/d0fba15c-f41b-4ee4-bea3-f0506d9b2d23">
-<img width="1394" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/ab526fae-7a71-4a7c-9aee-a3bfe4774958">
-<img width="1671" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/c6bcc511-e2f9-4616-bcca-47e1a8a25313">
-<img width="1670" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/7fbe3ef7-fb43-4925-9478-89ee08e44941">
+<img width="1609" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/4893c3cd-5055-468f-8138-6c5460bdd1e4">
 
 
 ## 准备需要用的变量
@@ -88,6 +65,29 @@ Argo 隧道认证方式有 json 和 token，使用两个方式其中之一
 <img width="814" alt="image" src="https://user-images.githubusercontent.com/92626977/233345537-c5b9dc27-35c4-407b-8809-b0ef68d9ad55.png">
 
 
+## Argo 认证的获取方式: json 或 token
+Argo 隧道认证方式有 json 和 token，使用两个方式其中之一。推荐前者，理由脚本会处理好所有的 Argo 隧道参数和路径，后者需要到 Cloudflare 官网手动设置，容易出错。
+
+### (方式 1 - Json):
+#### 通过 Cloudflare Json 生成网轻松获取 Argo 隧道 json 信息: https://fscarmen.cloudflare.now.cc
+
+<img width="893" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/5b734a9d-b4fd-40ca-b7e6-5a1732a53175">
+
+### (方式 2 - Token): 通过 Cloudflare 官网，手动生成 Argo 隧道 token 信息
+#### 到 cf 官网：https://dash.cloudflare.com/
+* 进入 zero trust 里生成 token 隧道和信息。
+* 其中数据路径 443/https 为 `proto.NezhaService`
+* ssh 路径 22/ssh 为 < client id >
+
+<img width="1672" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/0c467d8b-5fbc-4bde-ac8a-db70ed8798f0">
+<img width="1659" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/5aa4df19-f277-4582-8a4d-eef34a00085c">
+<img width="1470" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/ec06ec20-a68d-405c-b6de-cd4c52cbd8c0">
+<img width="1342" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/538707e1-a17b-4a0f-a8c0-63d0c7bc96aa">
+<img width="1020" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/9f5778fd-aa94-4fda-9d85-552b68f6d530">
+<img width="1652" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/d0fba15c-f41b-4ee4-bea3-f0506d9b2d23">
+<img width="1410" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/228b8e86-32a8-479a-8a86-89ed9b8b5b5e">
+
+
 ## PaaS 部署实例
 镜像 `fscarmen/argo-nezha:latest` ， 支持 amd64 和 arm64 架构
 
@@ -97,30 +97,27 @@ Argo 隧道认证方式有 json 和 token，使用两个方式其中之一
   | GH_USER        | 是 | github 的用户名，用于面板管理授权 |
   | GH_CLIENTID    | 是 | 在 github 上申请 |
   | GH_CLIENTSECRET| 是 | 在 github 上申请 |
-  | GH_BACKUP_USER  | 否 | 在 github 上备份哪吒服务端数据库的 github 用户名，不填则与面板管理授权的账户 GH_USER 一致  |
+  | GH_BACKUP_USER | 否 | 在 github 上备份哪吒服务端数据库的 github 用户名，不填则与面板管理授权的账户 GH_USER 一致  |
   | GH_REPO        | 否 | 在 github 上备份哪吒服务端数据库文件的 github 库 |
   | GH_EMAIL       | 否 | github 的邮箱，用于备份的 git 推送到远程库 |
   | GH_PAT         | 否 | github 的 PAT |
   | ARGO_AUTH      | 是 | Json: 从 https://fscarmen.cloudflare.now.cc 获取的 Argo Json<br> Token: 从 Cloudflare 官网获取 |
-  | DATA_DOMAIN    | 是 | 客户端与服务端的通信 argo 域名 |
-  | WEB_DOMAIN     | 是 | 面板 argo 域名 |
-  | SSH_DOMAIN     | 否 | ssh 用的 argo 域名 |
-  | SSH_PASSWORD   | 否 | ssh 的密码，只有在设置 SSH_JSON 后才生效，默认值 password |
+  | ARGO_DOMAIN    | 是 | Argo 域名 |
 
 Koyeb
 
-[![Deploy to Koyeb](https://www.koyeb.com/static/images/deploy/button.svg)](https://app.koyeb.com/deploy?type=docker&name=nezha&ports=80;http;/&env[GH_USER]=&env[GH_CLIENTID]=&env[GH_CLIENTSECRET]=&env[GH_REPO]=&env[GH_EMAIL]=&env[GH_PAT]=&env[ARGO_AUTH]=&env[DATA_DOMAIN]=&env[WEB_DOMAIN]=&env[SSH_DOMAIN]=&env[SSH_PASSWORD]=&image=docker.io/fscarmen/argo-nezha)
+[![Deploy to Koyeb](https://www.koyeb.com/static/images/deploy/button.svg)](https://app.koyeb.com/deploy?type=docker&name=nezha&ports=80;http;/&env[GH_USER]=&env[GH_CLIENTID]=&env[GH_CLIENTSECRET]=&env[GH_REPO]=&env[GH_EMAIL]=&env[GH_PAT]=&env[ARGO_AUTH]=&env[ARGO_DOMAIN]=&image=docker.io/fscarmen/argo-nezha)
 
 <img width="927" alt="image" src="https://user-images.githubusercontent.com/92626977/231088411-fbac3e6e-a8a6-4661-bcf8-7c777aa8ffeb.png">
 <img width="750" alt="image" src="https://user-images.githubusercontent.com/92626977/231088973-7134aefd-4c80-4559-8e40-17c3be11d27d.png">
-<img width="755" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/27a26b1b-6934-41a8-aca4-8a094c905850">
+<img width="877" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/8cfdb9ab-5fb6-483f-a382-47aef0d64bea">
 <img width="1187" alt="image" src="https://user-images.githubusercontent.com/92626977/231092893-c8f017a2-ee0e-4e28-bee3-7343158f0fa7.png">
 <img width="500" alt="image" src="https://user-images.githubusercontent.com/92626977/231094144-df6715bc-c611-47ce-a529-03c43f38102e.png">
 
 
-## VPS 部署实例
-* 注意: ARGO_JSON= 后面需要有单引号，不能去掉
-* 如果 VPS 是 IPv6 only 的，请先安装 WARP IPv4 或者双栈: https://github.com/fscarmen/warp
+## VPS 部署方式 1 --- docker
+* 注意: ARGO_DOMAIN= 后面需要有单引号，不能去掉
+* 如果 VPS 是 IPv6 only 的，请先安装 WARP IPv4 或者双栈: https://gitlab.com/fscarmen/warp
 * 备份目录为当前路径的 dashboard 文件夹
 
 ### docker 部署
@@ -128,6 +125,7 @@ Koyeb
 ```
 docker run -dit \
            --name nezha_dashboard \
+           --pull always \
            --restart always \
            -e GH_USER=<填 github 用户名> \
            -e GH_EMAIL=<填 github 邮箱> \
@@ -136,10 +134,8 @@ docker run -dit \
            -e GH_CLIENTID=<填获取的>  \
            -e GH_CLIENTSECRET=<填获取的> \
            -e ARGO_AUTH='<填获取的 Argo json 或者 token>' \
-           -e WEB_DOMAIN=<填自定义的> \
-           -e DATA_DOMAIN=<填自定义的> \
-           -e SSH_DOMAIN=<填自定义的> \
-           -e SSH_PASSWORD=<填自定义的> \
+           -e ARGO_DOMAIN=<填自定义的> \
+           -e GH_BACKUP_USER=<如与 GH_USER 一致，可以不要该环境变量> \
            fscarmen/argo-nezha
 ```
 
@@ -149,6 +145,7 @@ version: '3.8'
 services:
     argo-nezha:
         image: fscarmen/argo-nezha
+        pull: always
         container_name: nezha_dashboard
         restart: always
         environment:
@@ -159,31 +156,44 @@ services:
             - GH_CLIENTID=<填获取的>
             - GH_CLIENTSECRET=<填获取的>
             - ARGO_AUTH='<填获取的 Argo json 或者 token>'
-            - WEB_DOMAIN=<填自定义的>
-            - DATA_DOMAIN=<填自定义的>
-            - SSH_DOMAIN=<填自定义的>
-            - SSH_PASSWORD=<填自定义的>
+            - ARGO_DOMAIN=<填自定义的>
+            - GH_BACKUP_USER=<如与 GH_USER 一致，可以不要该环境变量>
+```
+
+
+## VPS 部署方式 2 --- 宿主机
+```
+bash <(wget -qO- https://raw.githubusercontent.com/fscarmen2/Argo-Nezha-Service-Container/main/dashboard.sh)
 ```
 
 
 ## 客户端接入
 通过gRPC传输，无需额外配置。使用面板给到的安装方式，举例
 ```
-curl -L https://raw.githubusercontent.com/naiba/nezha/master/script/install.sh -o nezha.sh && chmod +x nezha.sh && sudo ./nezha.sh install_agent data.seales.nom.za 443 eAxO9IF519fKFODlW0 --tls
+curl -L https://raw.githubusercontent.com/naiba/nezha/master/script/install.sh -o nezha.sh && chmod +x nezha.sh && sudo ./nezha.sh install_agent nezha.seales.nom.za 443 eAxO9IF519fKFODlW0 --tls
 ```
 
 
 ## SSH 接入
 * 以 macOS + WindTerm 为例，其他根据使用的 SSH 工具，结合官方官方说明文档: https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/use_cases/ssh/#2-connect-as-a-user
 * 官方 cloudflared 下载: https://github.com/cloudflare/cloudflared/releases
-* 以下输入命令举例
+* 以下输入命令举例:
+  SSH 用户名: root， 密码：<GH_CLIENTSECRET>
 ```
-<file path>/cloudflared access ssh --hostname ssh.seales.nom.za
+<file path>/cloudflared access ssh --hostname nezha.seales.nom.za/<GH_CLIENTID>
 ```
 
-<img width="834" alt="image" src="https://user-images.githubusercontent.com/92626977/233349393-cec79e11-346e-4a57-8357-8d153d75ee40.png">
-<img width="830" alt="image" src="https://user-images.githubusercontent.com/92626977/233350601-73de67f9-19ca-451f-b395-8721abbb3342.png">
+<img width="1180" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/507b037a-25c6-457f-b2b5-d54f4b70a2b6">
+<img width="828" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/80284f0b-e2d7-4adb-982a-969aca0cb5f6">
 <img width="955" alt="image" src="https://user-images.githubusercontent.com/92626977/233350802-754624e0-8456-4353-8577-1f5385fb8723.png">
+
+
+## 手动备份数据
+方法一: 把 Github 备份库里的 `README.md` 文件内容改为 `backup`
+
+<img width="970" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/c5b6bc4b-e69c-48ce-97d4-3f9be88515f3">
+
+方法二: ssh 进去后，容器版本运行 `/dashboard/backup.sh`; 非容器版本运行 `/opt/nezha/dashboard/backup.sh`
 
 
 ## 自动还原备份
@@ -212,28 +222,24 @@ tar czvf dashboard.tar.gz /dashboard
 
 ## 主体目录文件及说明
 ```
-.
-|-- dashboard
-|   |-- app                  # 哪吒面板主程序
-|   |-- argo.json            # Argo 隧道 json 文件，记录着使用隧道的信息
-|   |-- argo.yml             # Argo 隧道 yml 文件，用于在一同隧道下，根据不同域名来分流 web, gRPC 和 ssh 协议的作用
-|   |-- backup.sh            # 备份数据脚本
-|   |-- data
-|   |   |-- config.yaml      # 哪吒面板的配置，如 Github OAuth2 / gRPC 域名 / 端口 / 是否启用 TLS 等信息
-|   |   `-- sqlite.db        # SQLite 数据库文件，记录着面板设置的所有 severs 和 cron 等信息
-|   |-- entrypoint.sh        # 主脚本，容器运行后执行
-|   |-- nezha.csr            # SSL/TLS 证书签名请求
-|   |-- nezha.key            # SSL/TLS 证书的私钥信息
-|   |-- nezha.pem            # SSL/TLS 隐私增强邮件
-|   `-- restore.sh           # 还原备份脚本
-|-- usr
-|   `-- local
-|       `-- bin
-|           |-- cloudflared  # Cloudflare Argo 隧道主程序
-|           |-- grpcwebproxy # gRPC 反代主程序
-|           `-- nezha-agent  # 哪吒客户端，用于监控本地 localhost
-|-- dbfile                   # 记录最新的还原或备份文件名
-`-- version                  # 记录当前的面板 app 版本
+/dashboard/
+|-- app                  # 哪吒面板主程序
+|-- argo.json            # Argo 隧道 json 文件，记录着使用隧道的信息
+|-- argo.yml             # Argo 隧道 yml 文件，用于在一同隧道下，根据不同域名来分流 web, gRPC 和 ssh 协议的作用
+|-- backup.sh            # 备份数据脚本
+|-- restore.sh           # 还原备份脚本
+|-- dbfile               # 记录最新的还原或备份文件名
+|-- resource             # 面板主题、语言和旗帜等资料的文件夹
+|-- data
+|   |-- config.yaml      # 哪吒面板的配置，如 Github OAuth2 / gRPC 域名 / 端口 / 是否启用 TLS 等信息
+|   `-- sqlite.db        # SQLite 数据库文件，记录着面板设置的所有 severs 和 cron 等信息
+|-- entrypoint.sh        # 主脚本，容器运行后执行
+|-- nezha.csr            # SSL/TLS 证书签名请求
+|-- nezha.key            # SSL/TLS 证书的私钥信息
+|-- nezha.pem            # SSL/TLS 证书文件
+|-- cloudflared          # Cloudflare Argo 隧道主程序
+|-- grpcwebproxy         # gRPC 反代主程序
+`-- nezha-agent          # 哪吒客户端，用于监控本地 localhost
 ```
 
 
@@ -242,12 +248,14 @@ tar czvf dashboard.tar.gz /dashboard
 * 哪吒官网: https://nezha.wiki/ , TG 群: https://t.me/nezhamonitoring
 * 共穷国际老中医: http://solitud.es/
 * Akkia's Blog: https://blog.akkia.moe/
+* 胡桃's Blog: https://blog.萝莉.org/
 * HiFeng's Blog: https://www.hicairo.com/
 * 用 Cloudflare Tunnel 进行内网穿透: https://blog.outv.im/2021/cloudflared-tunnel/
 * 如何给 GitHub Actions 添加自己的 Runner 主机: https://cloud.tencent.com/developer/article/1756690
 * github self-hosted runner 添加与启动: https://blog.csdn.net/sinat_32188225/article/details/125978331
 * 如何从Docker镜像中导出文件: https://www.pkslow.com/archives/extract-files-from-docker-image
 * grpcwebproxy: https://github.com/improbable-eng/grpc-web/tree/master/go/grpcwebproxy
+* Applexad 的哪吒官方改版的面板二进制文件: https://github.com/applexad/nezha-binary-build
 
 
 ## 免责声明:

--- a/docs/en_US/case/case5.md
+++ b/docs/en_US/case/case5.md
@@ -14,9 +14,11 @@ Mirror backup (not live update): [Argo-Nezha-Service-Container](https://github.c
 - [How to get Argo authentication: json or token](case5.md#How-to-get-Argo-authentication-json-or-token)
 - [Variables to be used](case5.md#prepare-variables-to-be-used)
 - [PaaS Deployment Example](case5.md#paas-deployment-example)
-- [VPS Deployment Example](case5.md#vps-deployment-example)
+- [VPS Deployment Method 1 --- docker](case5.md#vps-deployment-method-1-----docker)
+- [VPS Deployment Method 2 --- hosts](case5.md#vps-deployment-method-2-----hosts)
 - [Client Access](case5.md#client-access)
 - [SSH Access](case5.md#ssh-access)
+- [Manual Backup data](case5.md#manual-backup-data)
 - [Auto Restore Backup](case5.md#automatically-restore-backups)
 - [Manual Restore Backup](case5.md#manually-restore-the-backup)
 - [Migrating data](case5.md#migrating-data)
@@ -27,7 +29,7 @@ Mirror backup (not live update): [Argo-Nezha-Service-Container](https://github.c
 * * *
 
 ## Project Features.
-* Wider scope of application --- As long as there is a network connection, Nezha server can be installed, such as Nas Virtual Machine, Container PaaS, etc.
+* Wider scope of application --- As long as there is a network connection, Nezha server can be installed, such as LXC, OpenVZ VPS, Nas Virtual Machine, Container PaaS, etc.
 * Argo tunnel breaks through the restriction of requiring a public network portal --- The traditional Nezha requires two public network ports, one for panel visiting and the other for client reporting, this project uses Cloudflare Argo tunnels and uses intranet tunneling.
 * IPv4 / v6 with higher flexibility --- The traditional Nezha needs to deal with IPv4/v6 compatibility between server and client, and also needs to resolve mismatches through tools such as warp. However, this project does not need to consider these issues at all, and can be docked arbitrarily, which is much more convenient and easy!
 * One Argo tunnel for multiple domains and protocols --- Create an intranet-penetrating Argo tunnel for three domains (hostname) and protocols, which can be used for panel access (http), client reporting (tcp) and ssh (optional).
@@ -38,32 +40,7 @@ Mirror backup (not live update): [Argo-Nezha-Service-Container](https://github.c
 * Default built-in local probes --- can easily monitor their own server information
 * More secure data --- Argo Tunnel uses TLS encrypted communication to securely transmit application traffic to the Cloudflare network, improving application security and reliability. In addition, Argo Tunnel protects against network threats such as IP leaks and DDoS attacks.
 
-<img width="1298" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/a1192434-fb60-4944-b6d0-de4235323e3d">
-
-
-## How to get Argo authentication: json or token
-The Argo Tunnel authentication methods are json and token, use one of the two methods.
-
-### (Methods 1 - Josn):
-#### Easily get Argo tunnel json information through Cloudflare Json Generation Network: https://fscarmen.cloudflare.now.cc
-
-<img width="862" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/7bf8fefd-328f-43a1-ada6-4472904e8adb">
-
-#### Visit Cloudflare website, add the domain name of the client reporting data (tcp) and ssh (optional) in the `DNS` record of the corresponding domain, and turn on Orange Cloud to enable CDN.
-
-<img width="1629" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/39ecc388-e66b-44a2-a339-c80e9d7ed8e2">
-<img width="1632" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/1ad2042e-46e6-41c3-9c16-14dc8699ee72">
-
-### (Methods 2 - Token): Manually generate Argo tunnel token information via Cloudflare website.
-#### Go to the cf website: https://dash.cloudflare.com/ and go to zero trust to generate token tunnels and messages.
-
-<img width="1672" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/c2952ef2-7a3d-4242-84bc-3cbada1d337c">
-<img width="1652" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/89b2b758-e550-413d-aa3e-216d226da7f4">
-<img width="1463" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/9f77e26b-a25d-4ff0-8425-1085708e19c3">
-<img width="1652" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/d0fba15c-f41b-4ee4-bea3-f0506d9b2d23">
-<img width="1394" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/ab526fae-7a71-4a7c-9aee-a3bfe4774958">
-<img width="1671" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/c6bcc511-e2f9-4616-bcca-47e1a8a25313">
-<img width="1670" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/7fbe3ef7-fb43-4925-9478-89ee08e44941">
+<img width="1609" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/4893c3cd-5055-468f-8138-6c5460bdd1e4">
 
 
 ## Prepare variables to be used
@@ -88,6 +65,29 @@ Add `https://` to the beginning of the panel's domain name and `/oauth2/callback
 <img width="716" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/499fb58d-9dc7-4b3f-84d7-d709d679ec80">
 
 
+## How to get Argo authentication: json or token
+Argo tunnel authentication methods include json and token, use one of the two methods. The former is recommended because the script will handle all the Argo tunnel parameters and paths, while the latter needs to be set manually on the Cloudflare website and is prone to errors.
+
+### (Methods 1 - Json):
+#### Easily get Argo tunnel json information through Cloudflare Json Generation Network: https://fscarmen.cloudflare.now.cc
+
+<img width="862" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/7bf8fefd-328f-43a1-ada6-4472904e8adb">
+
+### (Methods 2 - Token): Manually generate Argo tunnel token information via Cloudflare website.
+#### Go to the cf website: https://dash.cloudflare.com/
+* Go to zero trust and generate token tunnel and message.
+* The data path 443/https is proto.
+* ssh path 22/ssh for < client id >.
+
+<img width="1672" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/c2952ef2-7a3d-4242-84bc-3cbada1d337c">
+<img width="1652" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/89b2b758-e550-413d-aa3e-216d226da7f4">
+<img width="1463" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/9f77e26b-a25d-4ff0-8425-1085708e19c3">
+<img width="1342" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/538707e1-a17b-4a0f-a8c0-63d0c7bc96aa">
+<img width="1020" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/9f5778fd-aa94-4fda-9d85-552b68f6d530">
+<img width="1652" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/d0fba15c-f41b-4ee4-bea3-f0506d9b2d23">
+<img width="1401" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/ed3d0849-da78-4fd5-9510-d410afc5e6af">
+
+
 ## PaaS Deployment Example
 Image `fscarmen/argo-nezha:latest`, supports amd64 and arm64 architectures.
 
@@ -102,24 +102,21 @@ Variables used
   | GH_EMAIL | No | github's mailbox for git push backups to remote repositories |
   | GH_PAT | No | github's PAT |
   | ARGO_AUTH | Yes | Argo Json from https://fscarmen.cloudflare.now.cc<br>Argo token from Cloudflare official website  |
-  | DATA_DOMAIN | Yes | Client-server communication argo domain name |
-  | WEB_DOMAIN | Yes | Panel argo domain |
-  | SSH_DOMAIN | No | ssh for argo domain |
-  | SSH_PASSWORD | no | password for ssh, only works after setting SSH_JSON, default password |
+  | ARGO_DOMAIN | Yes | Argo domain |
 
 Koyeb
 
-[![Deploy to Koyeb](https://www.koyeb.com/static/images/deploy/button.svg)](https://app.koyeb.com/deploy?type=docker&name=nezha&ports=80;http;/&env[GH_USER]=&env[GH_CLIENTID]=&env[GH_CLIENTSECRET]=&env[GH_REPO]=&env[GH_EMAIL]=&env[GH_PAT]=&env[ARGO_AUTH]=&env[DATA_DOMAIN]=&env[WEB_DOMAIN]=&env[SSH_DOMAIN]=&env[SSH_PASSWORD]=&image=docker.io/fscarmen/argo-nezha)
+[![Deploy to Koyeb](https://www.koyeb.com/static/images/deploy/button.svg)](https://app.koyeb.com/deploy?type=docker&name=nezha&ports=80;http;/&env[GH_USER]=&env[GH_CLIENTID]=&env[GH_CLIENTSECRET]=&env[GH_REPO]=&env[GH_EMAIL]=&env[GH_PAT]=&env[ARGO_AUTH]=&env[ARGO_DOMAIN]=&image=docker.io/fscarmen/argo-nezha)
 
 <img width="927" alt="image" src="https://user-images.githubusercontent.com/92626977/231088411-fbac3e6e-a8a6-4661-bcf8-7c777aa8ffeb.png">
 <img width="1011" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/61fad972-1be9-4e8d-829a-8faea0c8ed64">
-<img width="778" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/c070b085-dd7a-4182-9439-857f3116814e">
+<img width="854" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/655c889e-3037-46d7-ab00-3e6085e86f66">
 <img width="1214" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/ddabdf3a-ca63-4523-b839-62c4d4c0caf2">
 <img width="881" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/e623f92d-878f-4eb8-9dfe-55b59770ba2f">
 
 
-## VPS Deployment Example
-* Note: ARGO_JSON= must be followed by single quotes, which cannot be removed.
+## VPS Deployment Method 1 --- docker
+* Note: ARGO_DOMAIN= must be followed by single quotes, which cannot be removed.
 * If the VPS is IPv6 only, please install WARP IPv4 or dual-stack first: https://github.com/fscarmen/warp
 * The backup directory is the dashboard folder in the current path.
 
@@ -128,6 +125,7 @@ Koyeb
 ```
 docker run -dit \
            --name nezha_dashboard \
+           --pull always \
            --restart always \
            -e GH_USER=<fill in github username> \
            -e GH_EMAIL=<fill in github email> \
@@ -136,10 +134,8 @@ docker run -dit \
            -e GH_CLIENTID=<fill in acquired> \
            -e GH_CLIENTSECRET=<fill in acquired> \
            -e ARGO_AUTH='<Fill in the fetched Argo json or token>' \
-           -e WEB_DOMAIN=<fill in customized> \
-           -e DATA_DOMAIN=<fill in customized> \
-           -e SSH_DOMAIN=<fill in customized> \
-           -e SSH_PASSWORD=<insert customized> \
+           -e ARGO_DOMAIN=<fill in customized> \
+           -e GH_BACKUP_USER=<If it is consistent with GH_USER, you can leave it blank> \
            fscarmen/argo-nezha
 ```
 
@@ -149,6 +145,7 @@ version: '3.8'
 services.
     argo-nezha.
         image: fscarmen/argo-nezha
+        --pull always
         container_name: nezha_dashboard
         restart: always
         environment:
@@ -159,10 +156,14 @@ services.
             - GH_CLIENTID=<fill in obtained>
             - GH_CLIENTSECRET=<fill in fetched>
             - ARGO_AUTH='<Fill in the fetched Argo json or token>'
-            - WEB_DOMAIN=<fill customized>
-            - DATA_DOMAIN=<fill in customized>
-            - SSH_DOMAIN=<insert customized>
-            - SSH_PASSWORD=<fill customized>
+            - ARGO_DOMAIN=<fill in customized>
+            - GH_BACKUP_USER=<If it is consistent with GH_USER, you can leave it blank>
+```
+
+
+## VPS Deployment Method 2 --- hosts
+```
+bash <(wget -qO- https://raw.githubusercontent.com/fscarmen2/Argo-Nezha-Service-Container/main/dashboard.sh)
 ```
 
 
@@ -176,14 +177,23 @@ curl -L https://raw.githubusercontent.com/naiba/nezha/master/script/install.sh -
 ## SSH access
 * Take macOS + WindTerm as an example, and other SSH tools depending on the one used, combined with the official documentation: https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/use_cases/ssh /#2-connect-as-a-user
 * Official cloudflared download: https://github.com/cloudflare/cloudflared/releases
-* The following are examples of input commands
+* The following are examples of input commands.
+  SSH user: root， SSH password：<GH_CLIENTSECRET>
 ```
-<filepath>/cloudflared access ssh --hostname ssh.seals.nom.za
+<filepath>/cloudflared access ssh --hostname ssh.seals.nom.za/<GH_CLIENTID>
 ```
 
-<img width="828" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/25c7bd31-21b5-4684-b1cf-d6d6e0e85058">
-<img width="830" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/20a8661c-90b8-4b77-a046-0a2e42d7fee5">
+<img width="1189" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/0aeb3939-51c7-47ac-a7fd-25a8a01d3df5">
+<img width="840" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/16961ade-aafc-4132-92a1-aa218e0fead9">
 <img width="1201" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/3146b2e2-f988-487f-ab63-00218eb4d570">
+
+
+## Manually backing up your data
+Method 1: Change the contents of the `README.md` file in the Github backup repository to `backup`
+
+<img width="970" alt="image" src="https://github.com/fscarmen2/Argo-Nezha-Service-Container/assets/92626977/c5b6bc4b-e69c-48ce-97d4- 3f9be88515f3">
+
+Method 2: After ssh, run `/dashboard/backup.sh` for container version; `/opt/nezha/dashboard/backup.sh` for VPS host version.
 
 
 ## Automatically restore backups
@@ -213,28 +223,24 @@ tar czvf dashboard.tar.gz /dashboard
 
 ## Main catalog files and descriptions
 ```
-.
-|-- dashboard
-|   |-- app                  # Nezha panel main program
-|   |-- argo.json            # Argo tunnel json file, which records information about using the tunnel.
-|   |-- argo.yml             # Argo tunnel yml file, used for streaming web, gRPC and ssh protocols under a single tunnel with different domains.
-|   |-- backup.sh            # Backup data scripts
-|   |-- data
-|   |   |-- config.yaml      # Configuration for the Nezha panel, e.g. Github OAuth2 / gRPC domain / port / TLS enabled or not.
-|   |   `-- sqlite.db        # SQLite database file that records all severs and cron settings for the panel.
-|   |-- entrypoint.sh        # The main script, which is executed after the container is run.
-|   |-- nezha.csr            # SSL/TLS certificate signing request
-|   |-- nezha.key            # Private key information for SSL/TLS certificate.
-|   |-- nezha.pem            # SSL/TLS Privacy Enhancement Email
-|   `-- restore.sh           # Restore backup scripts
-|-- usr
-|   `-- local
-|       `-- bin
-|           |-- cloudflared  # Cloudflare Argo tunnel main program.
-|           |-- grpcwebproxy # gRPC reverse proxy main program.
-|           `-- nezha-agent  # Nezha client, used to monitor the localhost.
-|-- dbfile                   # Record the name of the latest restore or backup file
-`-- version                  # Record the current panel app version
+/dashboard/
+|-- app                  # Nezha panel main program
+|-- argo.json            # Argo tunnel json file, which records information about using the tunnel.
+|-- argo.yml             # Argo tunnel yml file, used for streaming web, gRPC and ssh protocols under a single tunnel with different domains.
+|-- backup.sh            # Backup data scripts
+|-- restore.sh           # Restore backup scripts
+|-- dbfile               # Record the name of the latest restore or backup file
+|-- resource             # Folders of information on panel themes, languages, flags, etc.
+|-- data
+|   |-- config.yaml      # Configuration for the Nezha panel, e.g. Github OAuth2 / gRPC domain / port / TLS enabled or not.
+|   `-- sqlite.db        # SQLite database file that records all severs and cron settings for the panel.
+|-- entrypoint.sh        # The main script, which is executed after the container is run.
+|-- nezha.csr            # SSL/TLS certificate signing request
+|-- nezha.key            # Private key information for SSL/TLS certificate.
+|-- nezha.pem            # SSL/TLS certificate file.
+|-- cloudflared          # Cloudflare Argo tunnel main program.
+|-- grpcwebproxy         # gRPC reverse proxy main program.
+`-- nezha-agent          # Nezha client, used to monitor the localhost.
 ```
 
 
@@ -243,12 +249,14 @@ tar czvf dashboard.tar.gz /dashboard
 * Nezha website: https://nezha.wiki/ , TG Group: https://t.me/nezhamonitoring
 * Common Poverty International Old Chinese Medicine: http://solitud.es/
 * Akkia's Blog: https://blog.akkia.moe/
+* Ayaka's Blog: https://blog.xn--pn1aul.org/
 * HiFeng's Blog: https://www.hicairo.com/
 * Intranet Penetration with Cloudflare Tunnel: https://blog.outv.im/2021/cloudflared-tunnel/
 * How to add your own Runner host to GitHub Actions: https://cloud.tencent.com/developer/article/1756690
 * github self-hosted runner addition and startup: https://blog.csdn.net/sinat_32188225/article/details/125978331
 * How to export a file from a Docker image: https://www.pkslow.com/archives/extract-files-from-docker-image
 * grpcwebproxy: https://github.com/improbable-eng/grpc-web/tree/master/go/grpcwebproxy
+* Applexad's binary of Nezha's officially dashboard: https://github.com/applexad/nezha-binary-build
 
 
 ## Disclaimer


### PR DESCRIPTION
1. 增加非容器版本方案，支持 lxc / openvz 等不能安装 docker 的架构，也支持 Alpine 系统。
![image.png](https://img.imgdd.com/f210f3.d75bd6a2-5c82-4293-99d2-a7c82bcdb5ca.png)

2. 容器和非容器版本，都加了通过 github 的备份库触发备份功能，这样就不需要 ssh 进去才能手动备份了。方法是把备份库的 README.md 文件内容改为关键词 `backup`，等缓存好了就能自动备份了，并且把该文件的内容自动改为最新备份文件

![描述](https://img.imgdd.com/f210f3.13daba01-0e03-45be-b1fc-928858008999.png)

![描述](https://img.imgdd.com/f210f3.6142843f-4ef1-4220-b8a2-7591c9000328.png)