### PR TITLE
add oidc config

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -261,6 +261,7 @@ function getGuideSidebarEnUS() {
         { text: 'Customizing Agent Monitoring Items', link: '/en_US/guide/q7.html' },
         { text: 'Use Cloudflare Access As OAuth2 Provider', link: '/en_US/guide/q8.html' },
         { text: 'Enable GPU monitoring', link: '/en_US/guide/q9.html' },
+        { text: 'Enable OIDC authorization', link: '/en_US/guide/q10.html' },
       ]
     },
     {

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -189,6 +189,7 @@ function getGuideSidebarZhCN() {
         { text: '自定义 Agent 监控项目', link: '/guide/q7.html' },
         { text: '使用 Cloudflare Access 作为 OAuth2 提供方', link: '/guide/q8.html' },
         { text: '启用 GPU 监控', link: '/guide/q9.html' },
+        { text: '启用 OIDC 认证', link: '/guide/q10.html' },
       ]
     },
     {

--- a/docs/en_US/guide/dashboard.md
+++ b/docs/en_US/guide/dashboard.md
@@ -52,6 +52,11 @@ The following steps are for users who have already started using Zero Trust. If 
 
 **If using this method, after installing the Dashboard, modify the configuration file `/opt/nezha/dashboard/data/config.yaml`, and change the `Endpoint` configuration to the `Issuer` address saved earlier, e.g., `https://xxxxx.cloudflareaccess.com`, and restart the Dashboard.**
 
+### OIDC Configuration (Optional)
+Nezha supports OIDC authorization. For more details, visit the [OIDC Configuration](/en_US/guide/q10.html)
+
+
+
 ## Installing the Dashboard on the Server
 
 Run the installation script on the dashboard server:

--- a/docs/en_US/guide/dashboard.md
+++ b/docs/en_US/guide/dashboard.md
@@ -77,27 +77,6 @@ In the future, if you need to run the script again, run:
 ``` 
 to open the management script.  
 
-## Config OIDC
-Edit `config.ymal` to enable **OIDC**
-```yaml
-oauth2:
-  type: oidc  # (Required) Specifies the authentication type as OIDC
-  oidcDisplayName: OIDC  # (Optional, default is OIDC) The name displayed on the login page button
-  admin: ""  # (At least one of admin or adminGroups must be provided; default is empty) List of admin usernames, separated by commas. If a user is one of these, they will be considered an admin
-  adminGroups: ""  # (At least one of admin or adminGroups must be provided; default is empty) List of admin groups, separated by commas. If a user belongs to one of these groups, they will be considered an admin. Can be left blank if not using group management
-  clientid: # (Required) OIDC client ID
-  clientsecret: # (Required) OIDC client secret
-  oidcIssuer: https://auth.example.com/realms/master  # (Required) The issuer URL of the OIDC provider, can be found from the OIDC provider
-  # oidcLogoutUrl: https://auth.example.com/realms/master/protocol/openid-connect/logout  # (Has a bug, currently not working)
-  # oidcRegisterUrl: # (Optional) Registration URL of the OIDC provider
-  oidcScopes: openid,profile,email  # (Optional, default is openid,profile,email) Scopes requested from OIDC, separated by commas
-  oidcLoginClaim: sub  # (Optional, default is sub) The username field returned from OIDC, can be preferred_username, sub, or email
-  oidcGroupsClaim: groups  # (Required if using adminGroups; default is groups) The field returned from OIDC containing user group information, can be groups or roles
-  oidcAutoCreate: false  # (Optional, default is false) Whether to automatically create a user if they do not exist
-  oidcAutoLogin: false  # (Optional, default is false) Automatically redirect to the OIDC login page when the URL is /login
-
-```
-
 ## Configuring Reverse Proxy
 
 Create a new site in the aaPanel, with the domain filled in as the public access domain, such as “http://dashboard.example.com”. Then click “Settings” to enter the site settings options, select “Reverse Proxy” - “New Reverse Proxy”.

--- a/docs/en_US/guide/dashboard.md
+++ b/docs/en_US/guide/dashboard.md
@@ -52,10 +52,8 @@ The following steps are for users who have already started using Zero Trust. If 
 
 **If using this method, after installing the Dashboard, modify the configuration file `/opt/nezha/dashboard/data/config.yaml`, and change the `Endpoint` configuration to the `Issuer` address saved earlier, e.g., `https://xxxxx.cloudflareaccess.com`, and restart the Dashboard.**
 
-### OIDC Configuration (Optional)
-Nezha supports OIDC authorization. For more details, visit the [OIDC Configuration](/en_US/guide/q10.html)
-
-
+## OIDC Authentication Configuration (Optional)
+Nazha supports custom OIDC authentication login. For configuration details, please refer to the documentation: [Enable OIDC authorization](/en_US/guide/q10.html).
 
 ## Installing the Dashboard on the Server
 

--- a/docs/en_US/guide/dashboard.md
+++ b/docs/en_US/guide/dashboard.md
@@ -77,6 +77,27 @@ In the future, if you need to run the script again, run:
 ``` 
 to open the management script.  
 
+## Config OIDC
+Edit `config.ymal` to enable **OIDC**
+```yaml
+oauth2:
+  type: oidc  # (Required) Specifies the authentication type as OIDC
+  oidcDisplayName: OIDC  # (Optional, default is OIDC) The name displayed on the login page button
+  admin: ""  # (At least one of admin or adminGroups must be provided; default is empty) List of admin usernames, separated by commas. If a user is one of these, they will be considered an admin
+  adminGroups: ""  # (At least one of admin or adminGroups must be provided; default is empty) List of admin groups, separated by commas. If a user belongs to one of these groups, they will be considered an admin. Can be left blank if not using group management
+  clientid: # (Required) OIDC client ID
+  clientsecret: # (Required) OIDC client secret
+  oidcIssuer: https://auth.example.com/realms/master  # (Required) The issuer URL of the OIDC provider, can be found from the OIDC provider
+  # oidcLogoutUrl: https://auth.example.com/realms/master/protocol/openid-connect/logout  # (Has a bug, currently not working)
+  # oidcRegisterUrl: # (Optional) Registration URL of the OIDC provider
+  oidcScopes: openid,profile,email  # (Optional, default is openid,profile,email) Scopes requested from OIDC, separated by commas
+  oidcLoginClaim: sub  # (Optional, default is sub) The username field returned from OIDC, can be preferred_username, sub, or email
+  oidcGroupsClaim: groups  # (Required if using adminGroups; default is groups) The field returned from OIDC containing user group information, can be groups or roles
+  oidcAutoCreate: false  # (Optional, default is false) Whether to automatically create a user if they do not exist
+  oidcAutoLogin: false  # (Optional, default is false) Automatically redirect to the OIDC login page when the URL is /login
+
+```
+
 ## Configuring Reverse Proxy
 
 Create a new site in the aaPanel, with the domain filled in as the public access domain, such as “http://dashboard.example.com”. Then click “Settings” to enter the site settings options, select “Reverse Proxy” - “New Reverse Proxy”.

--- a/docs/en_US/guide/dashboard.md
+++ b/docs/en_US/guide/dashboard.md
@@ -53,6 +53,7 @@ The following steps are for users who have already started using Zero Trust. If 
 **If using this method, after installing the Dashboard, modify the configuration file `/opt/nezha/dashboard/data/config.yaml`, and change the `Endpoint` configuration to the `Issuer` address saved earlier, e.g., `https://xxxxx.cloudflareaccess.com`, and restart the Dashboard.**
 
 ## OIDC Authentication Configuration (Optional)
+
 Nazha supports custom OIDC authentication login. For configuration details, please refer to the documentation: [Enable OIDC authorization](/en_US/guide/q10.html).
 
 ## Installing the Dashboard on the Server

--- a/docs/en_US/guide/q10.md
+++ b/docs/en_US/guide/q10.md
@@ -1,0 +1,23 @@
+---
+outline: deep
+---
+# OIDC Configuration
+Edit `config.ymal` to enable **OIDC**
+```yaml
+oauth2:
+  type: oidc  # (Required) Specifies the authentication type as OIDC
+  oidcDisplayName: OIDC  # (Optional, default is OIDC) The name displayed on the login page button
+  admin: ""  # (At least one of admin or adminGroups must be provided; default is empty) List of admin usernames, separated by commas. If a user is one of these, they will be considered an admin
+  adminGroups: ""  # (At least one of admin or adminGroups must be provided; default is empty) List of admin groups, separated by commas. If a user belongs to one of these groups, they will be considered an admin. Can be left blank if not using group management
+  clientid: # (Required) OIDC client ID
+  clientsecret: # (Required) OIDC client secret
+  oidcIssuer: https://auth.example.com/realms/master  # (Required) The issuer URL of the OIDC provider, can be found from the OIDC provider
+  # oidcLogoutUrl: https://auth.example.com/realms/master/protocol/openid-connect/logout  # (Has a bug, currently not working)
+  # oidcRegisterUrl: # (Optional) Registration URL of the OIDC provider
+  oidcScopes: openid,profile,email  # (Optional, default is openid,profile,email) Scopes requested from OIDC, separated by commas
+  oidcLoginClaim: sub  # (Optional, default is sub) The username field returned from OIDC, can be preferred_username, sub, or email
+  oidcGroupsClaim: groups  # (Required if using adminGroups; default is groups) The field returned from OIDC containing user group information, can be groups or roles
+  oidcAutoCreate: false  # (Optional, default is false) Whether to automatically create a user if they do not exist
+  oidcAutoLogin: false  # (Optional, default is false) Automatically redirect to the OIDC login page when the URL is /login
+
+```

--- a/docs/guide/dashboard.md
+++ b/docs/guide/dashboard.md
@@ -52,6 +52,9 @@ outline: deep
 
 **如使用此方式，安装 Dashboard 完成后，需要修改配置文件 `/opt/nezha/dashboard/data/config.yaml`，将 `Endpoint` 配置修改为之前保存的 `Issuer` 地址，例如 `https://xxxxx.cloudflareaccess.com`，保存后需重启 Dashboard。**   
 
+### OIDC配置 （可选）
+哪吒支持自定义OIDC验证登录，配置详情可参考文档: [OIDC配置文档](/guide/q10.html)
+
 ## 在服务器中安装 Dashboard
 
 在面板服务器中，运行安装脚本：

--- a/docs/guide/dashboard.md
+++ b/docs/guide/dashboard.md
@@ -54,7 +54,7 @@ outline: deep
 
 ## OIDC 验证配置（可选）
 
-哪吒支持自定义 OIDC 验证登录。有关配置详情，请参考文档：[OIDC 配置文档](/guide/q10.html)。
+哪吒支持自定义 OIDC 验证登录。有关配置详情，请参考文档：[启用 OIDC 认证](/guide/q10.html)。
 
 ## 在服务器中安装 Dashboard
 

--- a/docs/guide/dashboard.md
+++ b/docs/guide/dashboard.md
@@ -81,27 +81,6 @@ curl -L https://gitee.com/naibahq/nezha/raw/master/script/install.sh -o nezha.sh
 ``` 
 来打开管理脚本。  
 
-## 使用OIDC验证
-修改`config.ymal`的内容来配置OIDC
-```yaml
-oauth2:
-  type: oidc  # (必填) 指定验证类型为OIDC
-  oidcDisplayName: OIDC  # (可选，默认值为OIDC) 登录页面按钮显示的名字
-  admin: ""  # (与adminGroups至少填写一项; 默认值为空) 管理员用户名，多个用户名用半角逗号分隔。如果用户在这些用户名列表中，则视为管理员
-  adminGroups: ""  # (与admin至少填写一项; 默认值为空) 管理员组，多个组名用半角逗号分隔。如果用户属于这些组，则视为管理员。如果不使用组管理，此项可省略
-  clientid: # (必填) OIDC客户端ID
-  clientsecret: # (必填) OIDC客户端密钥
-  oidcIssuer: https://auth.example.com/realms/master  # (必填) OIDC提供商的issuer地址，可从OIDC提供商查询
-  # oidcLogoutUrl: https://auth.example.com/realms/master/protocol/openid-connect/logout  # (有bug，目前不能使用)
-  # oidcRegisterUrl: # (可选) OIDC提供商的注册链接
-  oidcScopes: openid,profile,email  # (可选，默认值为openid,profile,email) OIDC请求的scope，多个scope用半角逗号分隔
-  oidcLoginClaim: sub  # (可选，默认值为sub) 从OIDC返回的用户名字段，可以是preferred_username、sub或email
-  oidcGroupsClaim: groups  # (如果使用adminGroups，则必填，默认值为groups) 从OIDC返回的用户组信息字段，可以是groups或roles
-  oidcAutoCreate: false  # (可选，默认值为false) 如果用户不存在，是否自动创建用户
-  oidcAutoLogin: false  # (可选，默认值为false) 当地址是/login时，是否自动跳转到OIDC登录页面
-
-```
-
 ## 配置反向代理
 
 在宝塔面板中新建一个站点，域名填写公开访问域名，如 “http://dashboard.example.com“ ，然后点击“设置”进入站点设置选项，选择“反向代理” - “新建反向代理”。

--- a/docs/guide/dashboard.md
+++ b/docs/guide/dashboard.md
@@ -52,8 +52,9 @@ outline: deep
 
 **如使用此方式，安装 Dashboard 完成后，需要修改配置文件 `/opt/nezha/dashboard/data/config.yaml`，将 `Endpoint` 配置修改为之前保存的 `Issuer` 地址，例如 `https://xxxxx.cloudflareaccess.com`，保存后需重启 Dashboard。**   
 
-### OIDC配置 （可选）
-哪吒支持自定义OIDC验证登录，配置详情可参考文档: [OIDC配置文档](/guide/q10.html)
+## OIDC 验证配置（可选）
+
+哪吒支持自定义 OIDC 验证登录。有关配置详情，请参考文档：[OIDC 配置文档](/guide/q10.html)。
 
 ## 在服务器中安装 Dashboard
 

--- a/docs/guide/dashboard.md
+++ b/docs/guide/dashboard.md
@@ -81,6 +81,27 @@ curl -L https://gitee.com/naibahq/nezha/raw/master/script/install.sh -o nezha.sh
 ``` 
 来打开管理脚本。  
 
+## 使用OIDC验证
+修改`config.ymal`的内容来配置OIDC
+```yaml
+oauth2:
+  type: oidc  # (必填) 指定验证类型为OIDC
+  oidcDisplayName: OIDC  # (可选，默认值为OIDC) 登录页面按钮显示的名字
+  admin: ""  # (与adminGroups至少填写一项; 默认值为空) 管理员用户名，多个用户名用半角逗号分隔。如果用户在这些用户名列表中，则视为管理员
+  adminGroups: ""  # (与admin至少填写一项; 默认值为空) 管理员组，多个组名用半角逗号分隔。如果用户属于这些组，则视为管理员。如果不使用组管理，此项可省略
+  clientid: # (必填) OIDC客户端ID
+  clientsecret: # (必填) OIDC客户端密钥
+  oidcIssuer: https://auth.example.com/realms/master  # (必填) OIDC提供商的issuer地址，可从OIDC提供商查询
+  # oidcLogoutUrl: https://auth.example.com/realms/master/protocol/openid-connect/logout  # (有bug，目前不能使用)
+  # oidcRegisterUrl: # (可选) OIDC提供商的注册链接
+  oidcScopes: openid,profile,email  # (可选，默认值为openid,profile,email) OIDC请求的scope，多个scope用半角逗号分隔
+  oidcLoginClaim: sub  # (可选，默认值为sub) 从OIDC返回的用户名字段，可以是preferred_username、sub或email
+  oidcGroupsClaim: groups  # (如果使用adminGroups，则必填，默认值为groups) 从OIDC返回的用户组信息字段，可以是groups或roles
+  oidcAutoCreate: false  # (可选，默认值为false) 如果用户不存在，是否自动创建用户
+  oidcAutoLogin: false  # (可选，默认值为false) 当地址是/login时，是否自动跳转到OIDC登录页面
+
+```
+
 ## 配置反向代理
 
 在宝塔面板中新建一个站点，域名填写公开访问域名，如 “http://dashboard.example.com“ ，然后点击“设置”进入站点设置选项，选择“反向代理” - “新建反向代理”。

--- a/docs/guide/q10.md
+++ b/docs/guide/q10.md
@@ -1,0 +1,22 @@
+---
+outline: deep
+---
+# 使用OIDC认证
+修改`config.ymal`的内容来配置OIDC
+```yaml
+oauth2:
+  type: oidc  # (必填) 指定验证类型为OIDC
+  oidcDisplayName: OIDC  # (可选，默认值为OIDC) 登录页面按钮显示的名字
+  admin: ""  # (与adminGroups至少填写一项; 默认值为空) 管理员用户名，多个用户名用半角逗号分隔。如果用户在这些用户名列表中，则视为管理员
+  adminGroups: ""  # (与admin至少填写一项; 默认值为空) 管理员组，多个组名用半角逗号分隔。如果用户属于这些组，则视为管理员。如果不使用组管理，此项可省略
+  clientid: # (必填) OIDC客户端ID
+  clientsecret: # (必填) OIDC客户端密钥
+  oidcIssuer: https://auth.example.com/realms/master  # (必填) OIDC提供商的issuer地址，可从OIDC提供商查询
+  # oidcLogoutUrl: https://auth.example.com/realms/master/protocol/openid-connect/logout  # (有bug，目前不能使用)
+  # oidcRegisterUrl: # (可选) OIDC提供商的注册链接
+  oidcScopes: openid,profile,email  # (可选，默认值为openid,profile,email) OIDC请求的scope，多个scope用半角逗号分隔
+  oidcLoginClaim: sub  # (可选，默认值为sub) 从OIDC返回的用户名字段，可以是preferred_username、sub或email
+  oidcGroupsClaim: groups  # (如果使用adminGroups，则必填，默认值为groups) 从OIDC返回的用户组信息字段，可以是groups或roles
+  oidcAutoCreate: false  # (可选，默认值为false) 如果用户不存在，是否自动创建用户
+  oidcAutoLogin: false  # (可选，默认值为false) 当地址是/login时，是否自动跳转到OIDC登录页面
+```


### PR DESCRIPTION
### 中文
修改`config.ymal`的内容来配置OIDC
```yaml
oauth2:
  type: oidc  # (必填) 指定验证类型为OIDC
  oidcDisplayName: OIDC  # (可选，默认值为OIDC) 登录页面按钮显示的名字
  admin: ""  # (与adminGroups至少填写一项; 默认值为空) 管理员用户名，多个用户名用半角逗号分隔。如果用户在这些用户名列表中，则视为管理员
  adminGroups: ""  # (与admin至少填写一项; 默认值为空) 管理员组，多个组名用半角逗号分隔。如果用户属于这些组，则视为管理员。如果不使用组管理，此项可省略
  clientid: # (必填) OIDC客户端ID
  clientsecret: # (必填) OIDC客户端密钥
  oidcIssuer: https://auth.example.com/realms/master  # (必填) OIDC提供商的issuer地址，可从OIDC提供商查询
  # oidcLogoutUrl: https://auth.example.com/realms/master/protocol/openid-connect/logout  # (有bug，目前不能使用)
  # oidcRegisterUrl: # (可选) OIDC提供商的注册链接
  oidcScopes: openid,profile,email  # (可选，默认值为openid,profile,email) OIDC请求的scope，多个scope用半角逗号分隔
  oidcLoginClaim: sub  # (可选，默认值为sub) 从OIDC返回的用户名字段，可以是preferred_username、sub或email
  oidcGroupsClaim: groups  # (如果使用adminGroups，则必填，默认值为groups) 从OIDC返回的用户组信息字段，可以是groups或roles
  oidcAutoCreate: false  # (可选，默认值为false) 如果用户不存在，是否自动创建用户
  oidcAutoLogin: false  # (可选，默认值为false) 当地址是/login时，是否自动跳转到OIDC登录页面

```

### Englisg

Edit `config.ymal` to enable **OIDC**
```yaml
oauth2:
  type: oidc  # (Required) Specifies the authentication type as OIDC
  oidcDisplayName: OIDC  # (Optional, default is OIDC) The name displayed on the login page button
  admin: ""  # (At least one of admin or adminGroups must be provided; default is empty) List of admin usernames, separated by commas. If a user is one of these, they will be considered an admin
  adminGroups: ""  # (At least one of admin or adminGroups must be provided; default is empty) List of admin groups, separated by commas. If a user belongs to one of these groups, they will be considered an admin. Can be left blank if not using group management
  clientid: # (Required) OIDC client ID
  clientsecret: # (Required) OIDC client secret
  oidcIssuer: https://auth.example.com/realms/master  # (Required) The issuer URL of the OIDC provider, can be found from the OIDC provider
  # oidcLogoutUrl: https://auth.example.com/realms/master/protocol/openid-connect/logout  # (Has a bug, currently not working)
  # oidcRegisterUrl: # (Optional) Registration URL of the OIDC provider
  oidcScopes: openid,profile,email  # (Optional, default is openid,profile,email) Scopes requested from OIDC, separated by commas
  oidcLoginClaim: sub  # (Optional, default is sub) The username field returned from OIDC, can be preferred_username, sub, or email
  oidcGroupsClaim: groups  # (Required if using adminGroups; default is groups) The field returned from OIDC containing user group information, can be groups or roles
  oidcAutoCreate: false  # (Optional, default is false) Whether to automatically create a user if they do not exist
  oidcAutoLogin: false  # (Optional, default is false) Automatically redirect to the OIDC login page when the URL is /login

```

