### PR TITLE
docs: sync English docs with Chinese content

### DIFF
--- a/docs/en_US/configuration/agent.md
+++ b/docs/en_US/configuration/agent.md
@@ -97,6 +97,10 @@ In the admin frontend, you can modify the Agent's configuration and apply it dir
 
   - When set to `true`, uses the Gitee repository as the automatic update source, better suited for servers in mainland China.
 
+- ##### **`use_atomgit_to_upgrade`**
+
+  - When set to `true`, uses the AtomGit repository as the automatic update source. Usually only needed when the default update source is unstable.
+
 - ##### **`use_ipv6_country_code`**
 
   - When set to `true`, forces the use of IPv6 addresses for country code queries (default uses IPv4).

--- a/docs/en_US/guide/agent.md
+++ b/docs/en_US/guide/agent.md
@@ -114,12 +114,13 @@ Alternatively, you can download and extract the Nezha Agent binaries in advance 
    gpu: false
    insecure_tls: false
    ip_report_period: 1800
-   report_delay: 1
+   report_delay: 3
    server: data.example.com:8008
    skip_connection_count: false
    skip_procs_count: false
    temperature: false
    tls: false
+   use_atomgit_to_upgrade: false
    use_gitee_to_upgrade: false
    use_ipv6_country_code: false
    uuid: your_uuid
@@ -254,12 +255,13 @@ In addition to the one-click script, Windows systems can also install the Agent 
    gpu: false
    insecure_tls: false
    ip_report_period: 1800
-   report_delay: 1
+   report_delay: 3
    server: data.example.com:8008
    skip_connection_count: false
    skip_procs_count: false
    temperature: false
    tls: false
+   use_atomgit_to_upgrade: false
    use_gitee_to_upgrade: false
    use_ipv6_country_code: false
    uuid: your_uuid
@@ -388,12 +390,13 @@ OpenWrt is a lightweight Linux distribution. Installing the Nezha Agent on OpenW
    gpu: false
    insecure_tls: false
    ip_report_period: 1800
-   report_delay: 1
+   report_delay: 3
    server: data.example.com:8008
    skip_connection_count: false
    skip_procs_count: false
    temperature: false
    tls: false
+   use_atomgit_to_upgrade: false
    use_gitee_to_upgrade: false
    use_ipv6_country_code: false
    uuid: your_uuid

--- a/docs/en_US/guide/api.md
+++ b/docs/en_US/guide/api.md
@@ -4,386 +4,391 @@ outline: deep
 
 # API Interface
 
-**Nezha Monitoring supports querying the status information of Agents using the API interface**
+Since v1, the Nezha Monitor Dashboard primarily uses the `/api/v1` path. APIs return JSON and are suitable for custom frontends, bots, automation scripts, and internal operations tools.
 
-## Creating a Token
+If you need a complete API list synchronized with the source code, use the Dashboard's built-in Swagger documentation first. This page keeps common APIs and calling rules for quick reference.
 
-Nezha Monitoring's API interface allows for Token authentication and Cookies authentication. To create a new Token, go to the admin panel, click on the avatar in the top right corner, select "API Token," and enter the Token management page. Click "Add Token", add a custom note, and click "Add".
+---
 
-To delete a Token, select the corresponding Token and click the delete icon on the right.
+## Get Complete API Documentation
 
-::: warning
-Tokens are the authentication credentials for the API interface. They are critical to the security of your Dashboard's information, so do not share your Token with others.
-:::
+The Dashboard mounts Swagger UI when debug mode is enabled:
 
-## Authentication Method
+1. Edit the Dashboard configuration file and enable debug mode:
 
-Ensure the request header contains `Authorization: Token` for authentication.
+   ```yaml
+   debug: true
+   ```
 
-Token authentication method:
-``` 
-Request Headers:
-Authorization: Token
+2. Restart the Dashboard.
+
+3. Check the Dashboard logs for the address. The default is similar to:
+
+   ```text
+   http://localhost:8008/swagger/index.html
+   ```
+
+If you are developing from source, you can also generate Swagger files in the repository root:
+
+```shell
+./script/bootstrap.sh
 ```
 
-## Usage Instructions
+The generated files are located in `cmd/dashboard/docs`.
 
 ::: warning
-Negative timestamps in the following examples represent `0000-00-00`. This currently indicates that the Agent has never reported since the Dashboard went online, but it is not recommended to use the positive or negative value to determine the status.
+`debug: true` exposes additional debug information and Swagger UI. It is not recommended to keep it enabled long-term in a public production environment. For online troubleshooting, enable it temporarily, then disable it and restart the Dashboard after finishing.
 :::
 
-::: tip
-**The request method is `GET`, and the response format is `JSON`.**
-:::
+---
+
+## Authentication
+
+### Log In to Get a Token
+
+Request:
+
+```http
+POST /api/v1/login
+Content-Type: application/json
+```
+
+Request body:
+
+```json
+{
+  "username": "admin",
+  "password": "your-password"
+}
+```
+
+Successful response:
+
+```json
+{
+  "success": true,
+  "data": {
+    "token": "JWT_TOKEN",
+    "expire": "2026-05-18T12:00:00+02:00"
+  }
+}
+```
+
+For later APIs that require login, include this request header:
+
+```http
+Authorization: Bearer JWT_TOKEN
+```
+
+### Guest-Accessible APIs
+
+Some read-only APIs support guest access, but they are limited by site configuration and server hidden settings:
+
+- After `force_auth` is enabled, guests cannot access server and service monitoring data.
+- If a server is hidden from guests, guests cannot access that server's data.
+- In service history and server metrics APIs, guests can only query `1d` period data.
+
+---
+
+## Response Format
+
+Normal APIs return:
+
+```json
+{
+  "success": true,
+  "data": {}
+}
+```
+
+Failures usually return:
+
+```json
+{
+  "success": false,
+  "error": "error message"
+}
+```
+
+Paginated list APIs return:
+
+```json
+{
+  "success": true,
+  "data": {
+    "value": [],
+    "pagination": {
+      "offset": 0,
+      "limit": 10,
+      "total": 100
+    }
+  }
+}
+```
+
+---
+
+## Common APIs
+
+### Get System Settings
+
+Request:
+
+```http
+GET /api/v1/setting
+```
+
+Notes:
+
+- Reads basic information such as site name, language, frontend templates, OAuth2 providers, and whether TSDB is enabled.
+- When accessed without login, only configuration allowed for guests is returned.
 
 ### Get Server List
 
 Request:
-``` 
-GET /api/v1/server/list?tag= 
-```
-
-Parameters:
-- `tag` (optional): ServerTag is the server group. Provide this parameter to query only servers in that group.
-
-Example response:
-```json
-{
-    "code": 0,
-    "message": "success",
-    "result": [
-        {
-            "id": 1,
-            "name": "Server1",
-            "tag": "Tag1",
-            "last_active": 1653014667,
-            "ipv4": "1.1.1.1",
-            "ipv6": "",
-            "valid_ip": "1.1.1.1"
-        },
-        {
-            "id": 2,
-            "name": "Server2",
-            "tag": "Tag2",
-            "last_active": -62135596800,
-            "ipv4": "",
-            "ipv6": "",
-            "valid_ip": ""
-        }
-    ]
-}
-```
-
-### Get Server Details
-
-Request:
-``` 
-GET /api/v1/server/details?id=&tag= 
-```
-
-Parameters:
-- `id` (optional): ServerID, multiple IDs separated by commas. Provide this parameter to query the server corresponding to that ID and ignore the `tag` parameter.
-- `tag` (optional): ServerTag, provide this parameter to query only servers in that group.
-
-Example response:
-```json
-{
-    "code": 0,
-    "message": "success",
-    "result": [
-        {
-            "id": 1,
-            "name": "Server1",
-            "tag": "Tag1",
-            "last_active": 1653015042,
-            "ipv4": "1.1.1.1",
-            "ipv6": "",
-            "valid_ip": "1.1.1.1",
-            "host": {
-                "Platform": "darwin",
-                "PlatformVersion": "12.3.1",
-                "CPU": [
-                    "Apple M1 Pro 1 Physical Core"
-                ],
-                "MemTotal": 17179869184,
-                "DiskTotal": 2473496842240,
-                "SwapTotal": 0,
-                "Arch": "arm64",
-                "Virtualization": "",
-                "BootTime": 1652683962,
-                "CountryCode": "hk",
-                "Version": ""
-            },
-            "status": {
-                "CPU": 17.33,
-                "MemUsed": 14013841408,
-                "SwapUsed": 0,
-                "DiskUsed": 2335048912896,
-                "NetInTransfer": 2710273234,
-                "NetOutTransfer": 695454765,
-                "NetInSpeed": 10806,
-                "NetOutSpeed": 5303,
-                "Uptime": 331080,
-                "Load1": 5.23,
-                "Load5": 4.87,
-                "Load15": 3.99,
-                "TcpConnCount": 195,
-                "UdpConnCount": 70,
-                "ProcessCount": 437
-            }
-        },
-        {
-            "id": 2,
-            "name": "Server2",
-            "tag": "Tag2",
-            "last_active": -62135596800,
-            "ipv4": "",
-            "ipv6": "",
-            "valid_ip": "",
-            "host": {
-                "Platform": "",
-                "PlatformVersion": "",
-                "CPU": null,
-                "MemTotal": 0,
-                "DiskTotal": 0,
-                "SwapTotal": 0,
-                "Arch": "",
-                "Virtualization": "",
-                "BootTime": 0,
-                "CountryCode": "",
-                "Version": ""
-            },
-            "status": {
-                "CPU": 0,
-                "MemUsed": 0,
-                "SwapUsed": 0,
-                "DiskUsed": 0,
-                "NetInTransfer": 0,
-                "NetOutTransfer": 0,
-                "NetInSpeed": 0,
-                "NetOutSpeed": 0,
-                "Uptime": 0,
-                "Load1": 0,
-                "Load5": 0,
-                "Load15": 0,
-                "TcpConnCount": 0,
-                "UdpConnCount": 0,
-                "ProcessCount": 0
-            }
-        }
-    ]
-}
-```
-
-### Get ICMP Ping / TCPing monitor value
-
-This API does not require authentication, except for servers with `HideForGuest` option enabled.
-
-Request:
-``` 
-GET /api/v1/monitor/{id}
-```
-
-Parameters:
-- `id` (required): ServerID, must be an positive integer.
-
-Example response:
-```json
-{
-    "code": 0,
-    "message": "success",
-    "result": [
-        {
-            "monitor_id": 1,
-            "server_id": 1,
-            "monitor_name": "Monitor1",
-            "server_name": "Server1",
-            "created_at": [
-                1722142860000,
-                1722142920000
-            ],
-            "avg_delay": [
-                68.2275,
-                70.1129
-            ]
-        },
-        {
-            "monitor_id": 2,
-            "server_id": 1,
-            "monitor_name": "Monitor2",
-            "server_name": "Server1",
-            "created_at": [
-                1722142860000,
-                1722142920000
-            ],
-            "avg_delay": [
-                66.656,
-                68.2153
-            ]
-        },
-        {
-            "monitor_id": 3,
-            "server_id": 1,
-            "monitor_name": "Monitor3",
-            "server_name": "Server1",
-            "created_at": [
-                1722142860000,
-                1722142920000
-            ],
-            "avg_delay": [
-                61.4525,
-                62.342
-            ]
-        }
-    ]
-}
-```
-
-Note: `created_at` corresponds with `avg_delay`.
-
-### Automatic Node Registration
-
-Description: Script for automating node registration. Example code is provided below.
-Reference: [https://github.com/naiba/nezha/pull/472](https://github.com/naiba/nezha/pull/472)
 
 ```http
-POST /api/v1/server/register?simple=1
+GET /api/v1/server
+Authorization: Bearer JWT_TOKEN
+```
+
+Notes:
+
+- Returns the list of servers that the current user has permission to manage.
+- Administrators can see all servers. Normal users can only see servers under their own account.
+- For real-time status streams, use the `GET /api/v1/ws/server` WebSocket API.
+
+### Get Server Real-Time Status Stream
+
+Request:
+
+```http
+GET /api/v1/ws/server
+Authorization: Bearer JWT_TOKEN
+```
+
+Notes:
+
+- Returns a WebSocket data stream for real-time server online status and resource usage updates.
+- If `force_auth` is not enabled, guests can also connect, but hidden servers are not included in guest data.
+
+### Get Service Monitoring Overview
+
+Request:
+
+```http
+GET /api/v1/service
+```
+
+Notes:
+
+- Returns current service monitoring status and cycle traffic statistics.
+- Logged-in users can see data they have permission to view. Guest access is limited by `force_auth` and hidden settings.
+
+### Get Service Monitoring History
+
+Request:
+
+```http
+GET /api/v1/service/{id}/history?period=1d
 ```
 
 Parameters:
 
-- `simple`: (optional): Specifies the format of the response data.
-    - When set to `simple=1` or `simple=true`, the response will only include a Token string (e.g., `8GYwaxYuLfU7zl7ndC`).
-    - Otherwise the response will return a complete JSON object:：`{"code": 200, "message": "Server created successfully","secret": "8GYwaxYuLfU7zl7ndC"}`
+- `id`: Service monitor ID.
+- `period`: Query period. Optional values are `1d`, `7d`, and `30d`; default is `1d`.
 
-Request Payload:
+The `1d` period uses 30-second granularity, suitable for detailed curves over the last 24 hours. The `7d` and `30d` periods use coarser aggregation to reduce query and transfer overhead.
 
-The payload can be completely empty (`{}`), and the system will apply the following default values:
-- `Name`: Defaults to the node’s IP address ($IP).
-- `Tag`: Defaults to "AutoRegister".
-- `Note`: Defaults to an empty string ("").
-- `HideForGuest`: Defaults to "on".
+Response example:
 
-You can also customize your data:
 ```json
-  "Name": "abcd",        // Node name
-  "Tag": "",             // Tag (optional)
-  "Note": "",            // Note or description (optional)
-  "HideForGuest": "on"   // Whether to hide from guests
+{
+  "success": true,
+  "data": {
+    "service_id": 1,
+    "service_name": "HTTPS",
+    "servers": [
+      {
+        "server_id": 1,
+        "server_name": "Server 1",
+        "stats": {
+          "avg_delay": 68.2,
+          "up_percent": 99.9,
+          "total_up": 1440,
+          "total_down": 1,
+          "data_points": [
+            {
+              "ts": 1760000000000,
+              "delay": 68.2,
+              "status": 1
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
 ```
+
+::: tip
+If TSDB is not enabled, service monitoring history is read from the database. After TSDB is enabled, it is queried from TSDB.
+:::
+
+### Get Server Metrics History
+
+Request:
+
+```http
+GET /api/v1/server/{id}/metrics?metric=cpu&period=1d
+```
+
+Parameters:
+
+- `id`: Server ID.
+- `metric`: Metric name. Required.
+- `period`: Query period. Optional values are `1d`, `7d`, and `30d`; default is `1d`.
+
+The `1d` period uses 30-second granularity, suitable for detailed curves over the last 24 hours. The `7d` and `30d` periods use coarser aggregation to reduce query and transfer overhead.
+
+Supported `metric` values:
+
+- `cpu`
+- `memory`
+- `swap`
+- `disk`
+- `net_in_speed`
+- `net_out_speed`
+- `net_in_transfer`
+- `net_out_transfer`
+- `load1`
+- `load5`
+- `load15`
+- `tcp_conn`
+- `udp_conn`
+- `process_count`
+- `temperature`
+- `uptime`
+- `gpu`
+
+Response example:
+
+```json
+{
+  "success": true,
+  "data": {
+    "server_id": 1,
+    "server_name": "Server 1",
+    "metric": "cpu",
+    "data_points": [
+      {
+        "ts": 1760000000000,
+        "value": 12.34
+      }
+    ]
+  }
+}
+```
+
+::: warning
+This API depends on TSDB. If TSDB is not enabled, the API still returns success, but `data_points` is empty. For TSDB configuration, see [Dashboard Configuration](/en_US/configuration/dashboard.html#tsdb).
+:::
+
+### Get Servers Under a Service
+
+Request:
+
+```http
+GET /api/v1/service/{id}/server
+```
+
+Notes:
+
+- Returns the server list associated with a service monitor.
+- Commonly used by custom frontends to display node-level status for a monitor.
+
+### Get Service Monitors Under a Server
+
+Request:
+
+```http
+GET /api/v1/server/{id}/service
+```
+
+Notes:
+
+- Returns the service monitor list associated with a server.
+- Commonly used on server detail pages to display HTTP, TCP, Ping, and other monitors that the server participates in.
+
+---
+
+## Management APIs
+
+Management APIs require login, and some also require administrator privileges. Common paths:
+
+- Users and profiles: `/api/v1/profile`, `/api/v1/user`
+- Servers: `/api/v1/server`, `/api/v1/server/config`, `/api/v1/batch-move/server`
+- Server groups: `/api/v1/server-group`
+- Notification methods: `/api/v1/notification`
+- Notification groups: `/api/v1/notification-group`
+- Alert rules: `/api/v1/alert-rule`
+- Service monitoring: `/api/v1/service`
+- Scheduled tasks: `/api/v1/cron`
+- DDNS: `/api/v1/ddns`
+- NAT: `/api/v1/nat`
+- Online terminal: `/api/v1/terminal`, `/api/v1/ws/terminal/{id}`
+- File management: `/api/v1/file`, `/api/v1/ws/file/{id}`
+- WAF and online users: `/api/v1/waf`, `/api/v1/online-user`
+- System settings and maintenance: `/api/v1/setting`, `/api/v1/maintenance`
+
+Use the Swagger documentation as the source of truth for fields, request bodies, and permission requirements. Before writing management automation scripts, test them in a staging environment to avoid bulk changes to servers, notifications, tasks, or user configuration.
+
+---
 
 ## Usage Examples
 
-### Get All Server Information
+### Get Server List
 
 ```python
 import requests
 
-url = "http://your-dashboard/api/v1/server/list"
-headers = {
-    "Authorization": "your_token"
-}
+base_url = "https://nezha.example.com"
+token = "JWT_TOKEN"
 
-response = requests.get(url, headers=headers)
-data = response.json()
+response = requests.get(
+    f"{base_url}/api/v1/server",
+    headers={"Authorization": f"Bearer {token}"},
+    timeout=10,
+)
+response.raise_for_status()
 
-for server in data['result']:
-    print(f"Server Name: {server['name']}, Last Active: {server['last_active']}, IP: {server['valid_ip']}")
+payload = response.json()
+if not payload.get("success"):
+    raise RuntimeError(payload.get("error", "unknown error"))
+
+for server in payload["data"]:
+    print(server["id"], server["name"])
 ```
 
-### Get Specific Server Details
+### Query 24-Hour CPU History
 
 ```python
 import requests
 
-server_id = 1  # Replace with your server ID
-url = f"http://your-dashboard/api/v1/server/details?id={server_id}"
-headers = {
-    "Authorization": "your_token"
-}
+base_url = "https://nezha.example.com"
+server_id = 1
 
-response = requests.get(url, headers=headers)
-data = response.json()
+response = requests.get(
+    f"{base_url}/api/v1/server/{server_id}/metrics",
+    params={"metric": "cpu", "period": "1d"},
+    timeout=10,
+)
+response.raise_for_status()
 
-server = data['result'][0]
-print(f"Server Name: {server['name']}")
-print(f"CPU Usage: {server['status']['CPU']}%")
-print(f"Memory Used: {server['status']['MemUsed']} bytes")
-print(f"Disk Used: {server['status']['DiskUsed']} bytes")
-print(f"Network In Speed: {server['status']['NetInSpeed']} bytes/s")
-print(f"Network Out Speed: {server['status']['NetOutSpeed']} bytes/s")
-```
+payload = response.json()
+if not payload.get("success"):
+    raise RuntimeError(payload.get("error", "unknown error"))
 
-With the above example code, you can easily obtain and process server status information, enabling automated monitoring and management.
-
-### Automatic Node Registration
-1. Create a file named `nezha_register.sh`, and copy the following content into it:
-```bash
-#!/bin/bash
-
-# Exit if NEZHA_TOKEN is not set
-if [ -z "${NEZHA_TOKEN}" ]; then
-    echo "NEZHA_TOKEN is not set. Exiting."
-    exit 0
-fi
-
-# Set default values if variables are not set
-NEZHA_PROBE_ADDRESS="${NEZHA_PROBE_ADDRESS:-probe.example.com}"
-NEZHA_PROBE_PORT="${NEZHA_PROBE_PORT:-5555}"
-NEZHA_DASHBOARD_URL="${NEZHA_DASHBOARD_URL:-https://nezha.example.com}"
-
-NODE_NAME=${NODE_NAME:-$(hostname)}
-
-# Send POST request and capture response and HTTP status code
-response=$(curl -s -o response_body.json -w "%{http_code}" -X POST "${NEZHA_DASHBOARD_URL}/api/v1/server/register?simple=true" \
-  -H "Content-Type: application/json" \
-  -H "Authorization: ${NEZHA_TOKEN}" \
-  -d "{\"Name\": \"${NODE_NAME}\"}")
-
-# Extract HTTP status code and Nezha secret
-HTTP_CODE="$response"
-NEZHA_SECRET=$(cat response_body.json)
-rm -f response_body.json
-
-if [ "$HTTP_CODE" != "200" ]; then
-    echo "Failed to get Nezha Secret. HTTP status code: $HTTP_CODE"
-    exit 1
-fi
-
-# Additional check for NEZHA_SECRET to ensure it's not JSON-formatted (indicating failure)
-if [[ "${NEZHA_SECRET:0:1}" == "{" ]]; then
-    echo "Failed to get Nezha Secret. Received response: ${NEZHA_SECRET}"
-    exit 1
-fi
-
-# Download and execute the install script with cleanup
-curl -fsSL https://raw.githubusercontent.com/nezhahq/scripts/main/install_en.sh -o nezha.sh && \
-chmod +x nezha.sh || { echo "Failed to download or make the script executable"; exit 1; }
-
-# Clean up nezha.sh on exit
-trap 'rm -f nezha.sh' EXIT
-
-# Run the Nezha agent installation script
-CMD="./nezha.sh install_agent "${NEZHA_PROBE_ADDRESS}" "${NEZHA_PROBE_PORT}" "${NEZHA_SECRET}" --tls"
-
-echo "Run commnad : ${CMD}"
-
-eval $CMD
-```
-2. Grant execution permission to the script: `chmod +x nezha_register.sh`
-3. Get `Token` from Nezha dashboard, e.g. `POXbxorKJBM8wPMKX8r2PdMblyXvpggB`
-4. Set Environment Variables
-```bash
-export NEZHA_TOKEN="POXbxorKJBM8wPMKX8r2PdMblyXvpggB" # Obtain this token from the dashboard
-export NEZHA_PROBE_ADDRESS="your_probe_address"        # Set your probe address
-export NEZHA_DASHBOARD_URL="https://nezha.example.com" # Replace with your dashboard URL
-export NEZHA_PROBE_PORT="5555"                         # Modify this port if needed
-```
-5. Run the script to complete node registration and probe installation:
-```bash
-./nezha_register.sh
-```
-6. If the script runs successfully, you will see output like the following:
-```bash
-Run command: ./nezha.sh install_agent probe.example.com 5555 YOUR_SECRET --tls
+for point in payload["data"]["data_points"]:
+    print(point["ts"], point["value"])
 ```

--- a/docs/en_US/guide/loginq.md
+++ b/docs/en_US/guide/loginq.md
@@ -2,64 +2,26 @@
 outline: deep
 ---
 
-# FAQ about logging into the Dashboard
+# Login FAQ
 
-## Stuck Page/Connection Refused/Long Response Time After Login Callback
+Since v1, the Dashboard uses local account login and supports binding local accounts to OAuth2 third-party accounts. Legacy GitHub OAuth login issues no longer apply to the current login flow.
 
-These issues can manifest in various ways, but ultimately the browser cannot display correctly after login.
+## Forgot Administrator Password
 
-1. Your server cannot connect to Github/Gitee, which is most common when configuring Github on servers in mainland China. You may try several times or switch to Cloudflare Access.
-2. You have configured the callback address incorrectly. Ensure that your callback address is correct and that both the **port and protocol** are accurate!
-3. An unknown error occurred on the Dashboard. You can use a script to check the logs.
+See [Initialize User Password](/en_US/guide/q13.html). After resetting it, log in to the admin frontend and change it to a new strong password as soon as possible.
 
-::: tip
-What is a protocol?
-In the browser, the string that ends your domain with `://` is the protocol, usually `http` or `https`. Since there may be multiple protocol+domain+port combinations available for accessing the Dashboard in a normal deployment, make sure to choose the most appropriate one as the callback.
-:::   
+## OAuth2 Login Failed
 
-### How to Check if My Callback Address is Wrong?
+Check the following first:
 
-Ensure that the protocol+domain+port displayed in the browser before login and after the callback are consistent.  
-Ensure that your path is `/oauth2/callback`, **all in lowercase**.
+1. The `oauth2` field in the Dashboard configuration uses the new structure. See [Setting Up OAuth 2.0 Binding](/en_US/guide/q14.html).
+2. The Callback URL on the third-party platform is `https://your-dashboard-domain/api/v1/oauth2/callback`.
+3. You have already logged in with a local account and completed OAuth2 binding on the profile page.
 
-## Errors After Logging into the Admin Panel
+If no binding relationship exists yet, OAuth2 cannot directly log in to a local account.
 
-### http: named cookie not present
+## Login Endpoint Is Frequently Tried or Incorrectly Blocked
 
-1. Clear cookies and log in again, or try a different browser.
-2. Check the callback address to ensure it is correct and that both the **port and protocol** are accurate! The address initiating the request must be in the same domain as the callback address, with the port, protocol, and domain (or IP) all matching.
+v1 introduces a Web Application Firewall to limit login brute force attempts. If the Dashboard is deployed behind a reverse proxy or CDN, configure the [Frontend Real IP Request Header](/en_US/guide/q12.html) correctly; otherwise, the Dashboard may misidentify visitor IPs and block incorrectly.
 
-### lookup xxx
-
-The container DNS resolution failed, usually due to modified iptables configurations.  
-It is recommended to restart Docker first, `sudo systemctl restart docker`, then restart the Dashboard using the script.  
-If the lookup error persists, check if there are other tools controlling iptables, such as firewall.  
-This issue might also be related to the kernel, so try switching to the official kernel.
-
-### Invalid authorization method, or the login callback address is invalid, expired, or has been revoked
-
-This issue appears only when using Gitee login, and the reason is unclear. Switching to GitHub is recommended.
-
-### oauth2: server response missing access_token
-
-This could be caused by various factors, most likely a network issue. Check your network and try again.  
-If unresolved, switching to Github or another method is recommended.
-
-### The user is not an admin of this site and cannot log in
-
-You logged in with the wrong account or configured the wrong username. Note that **the username is not an email**, and you can use a script to modify it.  
-For Cloudflare Access users, note that your username is not an email but a User ID.
-
-### dial tcp xxx:443 i/o timeout
-
-This is a network issue. Try restarting Docker first, `sudo systemctl restart docker`, then restart the Dashboard using the script.  
-If you are configuring Github login on a server in mainland China, switching to Cloudflare Access is recommended to avoid network interference.
-
-### net/http: TLS handshake timeout
-
-Same as above.
-
-### Unable to receive email verification codes using Cloudflare Access as an OAuth2 Provider
-
-- Ensure that the email verification policy has been correctly configured in `Policies`.
-- Verify that the email address you provided is correct. Note that email addresses not on the policy whitelist will not receive verification codes.
+If an IP has already been blocked by mistake, use an administrator account to remove the corresponding block record under **System Settings → Web Application Firewall**.

--- a/docs/en_US/guide/nat.md
+++ b/docs/en_US/guide/nat.md
@@ -35,6 +35,7 @@ If using control panels like AApanel or other management tools, ensure the domai
 2. **Add a Tunnel Configuration**  
    Click the **Add** button and provide the following details:
    - **Name**: A custom name for the tunnel, such as `OpenWrt Login Page`.
+   - **Enable**: Controls whether this tunnel configuration takes effect. After disabling it, the Dashboard rejects tunnel requests to the bound domain. This is suitable for temporarily disabling an internal service without deleting the configuration.
    - **Server ID**: The target Agent's ID.
    - **Local Service**: The internal service address to expose, in the format `IP:port` (e.g., `127.0.0.1:80`).
    - **Bound Domain**: The public domain name (e.g., `service-1.example.com`). If the Dashboard uses a non-standard port (e.g., `8008`), include the port in the configuration.

--- a/docs/en_US/guide/notifications.md
+++ b/docs/en_US/guide/notifications.md
@@ -4,71 +4,87 @@ outline: deep
 
 # Notification Settings
 
-Nezha Monitoring supports monitoring server metrics such as load, CPU, memory, disk, bandwidth, monthly traffic, process count, and connections. Notifications are triggered when user-defined thresholds are reached.
-
----
+Nezha Monitor can monitor server load, CPU, memory, disk, traffic, monthly traffic, process count, and connection count, and send notifications when user-defined thresholds are reached.
 
 ## Flexible Notification Methods
 
-- **Message Placeholders**: 
-  - `#DATETIME#`: Represents the event timestamp, automatically replaced with the actual time when a notification is triggered.
-  - `#NEZHA#`: A placeholder for notification content, replaced with the actual message.
+- In panel messages, `#DATETIME#` represents the timestamp when the event occurred and is automatically replaced with the actual time when a notification is triggered.
+- `#NEZHA#` is the panel message placeholder and is automatically replaced with the actual message content when a notification is triggered.
+- **Request body format:**
+  - When the request type is **FORM**, use `key:value` format. `value` can contain placeholders that are automatically replaced during notification.
+  - When the request type is **JSON**, simple string replacement is performed and the result is submitted directly to the `URL`.
+- The **URL** can also contain placeholders, which are replaced during the request.
+- **Verify TLS**: When enabled, HTTPS notification requests verify the certificate chain and domain. If the notification service uses a self-signed certificate or internal test certificate, you may need to disable this option.
+- **Skip Check**: When adding or modifying a notification method, the Dashboard sends a test message by default. After checking “Skip Check”, the configuration is saved directly. This is useful when the notification service is temporarily unreachable but you are sure the parameters are correct.
+- **Format Metric Units:** If “Format Metric Units” is enabled, `#SERVER.CPU#`, `#SERVER.MEM#`, `#SERVER.SWAP#`, `#SERVER.DISK#`, `#SERVER.SPEEDIN#`, `#SERVER.SPEEDOUT#`, `#SERVER.TRANSFERIN#`, and `#SERVER.TRANSFEROUT#` output human-readable values with units, such as `12.34 %`, `1.23 GB`, and `10.50 MB/s`. If disabled, these placeholders keep their raw numeric values, which is suitable for webhooks that need pure numbers.
+- **Webhook Target Restrictions**: Notification URLs only support `http` and `https`. For security reasons, the Dashboard rejects notification requests pointing to localhost, private networks, link-local addresses, reserved addresses, multicast addresses, and other non-public targets, and it does not automatically follow redirects. If you need to push to an internal service, receive the notification through a publicly accessible relay first.
 
-- **Request Body Formats**:
-  - For **FORM** requests, use `key:value` pairs, with placeholders in `value` replaced dynamically.
-  - For **JSON** requests, strings are replaced before submission to the `URL`.
-
-- **URL Placeholders**: Placeholders in the URL are replaced with corresponding values during the request.
-
-**Refer to the examples below or customize notification methods based on your needs.**
+**Refer to the following notification examples. You can also customize push methods as needed.**
 
 ---
 
 ### Supported Placeholders
 
-| Placeholder            | Description               |
-| ----------------------- | ------------------------- |
-| `#NEZHA#`              | Notification content      |
-| `#SERVER.NAME#`        | Server name               |
-| `#SERVER.IP#`          | Server IP address         |
-| `#SERVER.IPV4#`        | Server IPv4 address       |
-| `#SERVER.IPV6#`        | Server IPv6 address       |
-| `#SERVER.CPU#`         | CPU usage rate            |
-| `#SERVER.MEM#`         | Memory usage rate         |
-| `#SERVER.SWAP#`        | Swap usage rate           |
-| `#SERVER.DISK#`        | Disk usage rate           |
-| `#SERVER.SPEEDIN#`     | Real-time inbound speed    |
-| `#SERVER.SPEEDOUT#`    | Real-time outbound speed  |
-| `#SERVER.TRANSFERIN#`  | Total inbound traffic      |
-| `#SERVER.TRANSFEROUT#` | Total outbound traffic    |
-| `#SERVER.LOAD1#`       | 1-minute load average     |
-| `#SERVER.LOAD5#`       | 5-minute load average     |
-| `#SERVER.LOAD15#`      | 15-minute load average    |
+| Placeholder | Meaning |
+| --- | --- |
+| `#NEZHA#` | Notification content |
+| `#SERVER.ID#` | Server ID |
+| `#SERVER.NAME#` | Server name |
+| `#SERVER.IP#` | Server IP |
+| `#SERVER.IPV4#` | Server IPv4 address |
+| `#SERVER.IPV6#` | Server IPv6 address |
+| `#SERVER.CPU#` | CPU usage, outputs a percentage when “Format Metric Units” is enabled |
+| `#SERVER.MEM#` | Memory usage, outputs a percentage when “Format Metric Units” is enabled |
+| `#SERVER.SWAP#` | Swap usage, outputs a percentage when “Format Metric Units” is enabled |
+| `#SERVER.DISK#` | Disk usage, outputs a percentage when “Format Metric Units” is enabled |
+| `#SERVER.SPEEDIN#` | Real-time inbound speed, outputs `KB/s`, `MB/s`, etc. when “Format Metric Units” is enabled |
+| `#SERVER.SPEEDOUT#` | Real-time outbound speed, outputs `KB/s`, `MB/s`, etc. when “Format Metric Units” is enabled |
+| `#SERVER.TRANSFERIN#` | Total inbound traffic, outputs `KB`, `MB`, `GB`, etc. when “Format Metric Units” is enabled |
+| `#SERVER.TRANSFEROUT#` | Total outbound traffic, outputs `KB`, `MB`, `GB`, etc. when “Format Metric Units” is enabled |
+| `#SERVER.CPUUSED#` | Raw CPU value |
+| `#SERVER.MEMUSED#` | Used memory in bytes |
+| `#SERVER.MEMTOTAL#` | Total memory in bytes |
+| `#SERVER.SWAPUSED#` | Used swap in bytes |
+| `#SERVER.SWAPTOTAL#` | Total swap in bytes |
+| `#SERVER.DISKUSED#` | Used disk in bytes |
+| `#SERVER.DISKTOTAL#` | Total disk in bytes |
+| `#SERVER.NETINSPEED#` | Raw inbound speed in bytes/second |
+| `#SERVER.NETOUTSPEED#` | Raw outbound speed in bytes/second |
+| `#SERVER.NETINTRANSFER#` | Raw inbound traffic in bytes |
+| `#SERVER.NETOUTTRANSFER#` | Raw outbound traffic in bytes |
+| `#SERVER.LOAD1#` | 1-minute load |
+| `#SERVER.LOAD5#` | 5-minute load |
+| `#SERVER.LOAD15#` | 15-minute load |
+| `#SERVER.TCPCONNCOUNT#` | TCP connection count |
+| `#SERVER.UDPCONNCOUNT#` | UDP connection count |
 
 ---
 
 ### Bark Example
 
 <details>
-  <summary>Expand/Collapse</summary>
+  <summary>Expand/collapse</summary>
 
 - **Name**: Bark
-- **URL Composition**:
-  - GET Requests: `/:key/:body`, `/:key/:title/:body`, or `/:key/:category/:title/:body`
-  - POST Requests: `/push`
-- **Request Method**: GET or POST
-- **Request Type**: 
-  - GET: Default
-  - POST: `form`
-- **Body** (POST Example):
-  ```json
-  {
-    "title": "#SERVER.NAME#",
-    "device_key": "xxxxxxxxx",
-    "body": "#NEZHA#",
-    "icon": "https://xxxxxxxx/nz.png"
-  }
-  ```
+- **URL composition**:
+  - GET request: `/:key/:body`, `/:key/:title/:body`, or `/:key/:category/:title/:body`
+  - POST request: `/push`
+- **Request method**:
+  - GET or POST
+- **Request type**:
+  - GET request: default
+  - POST request: `form`
+- **Body**:
+  - GET request: empty
+  - POST request:
+    ```json
+    {
+      "title": "#SERVER.NAME#",
+      "device_key": "xxxxxxxxx",
+      "body": "#NEZHA#",
+      "icon": "https://xxxxxxxx/nz.png"
+    }
+    ```
 
 </details>
 
@@ -77,20 +93,20 @@ Nezha Monitoring supports monitoring server metrics such as load, CPU, memory, d
 ### Slack Example (Contributed by [@cantoblanco](https://github.com/cantoblanco))
 
 <details>
-  <summary>Expand/Collapse</summary>
+  <summary>Expand/collapse</summary>
 
-#### URL Parameter Setup
+#### Get URL Parameters
 
-1. **Create a Slack App**: Visit [Slack API](https://api.slack.com/apps) and create a new App.
-2. **Enable Incoming Webhook**: Add and activate Incoming Webhooks on the App's settings page.
-3. **Generate Webhook URL**: Add a new webhook to a workspace, select a channel, and authorize. Copy the generated URL.
+1. **Create a Slack App**: Create a new app at [Slack API](https://api.slack.com/apps).
+2. **Add Incoming Webhook**: Add Incoming Webhooks on the app feature page and activate them.
+3. **Generate Webhook URL**: Click “Add New Webhook to Workspace”, select a channel, and authorize it to get the Webhook URL.
 
-**Notification Configuration:**
+**Notification configuration:**
 
 - **Name**: Slack
 - **URL**: `https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX`
-- **Request Method**: POST
-- **Request Type**: JSON
+- **Request method**: `POST`
+- **Request type**: `JSON`
 - **Body**:
   ```json
   {
@@ -102,26 +118,221 @@ Nezha Monitoring supports monitoring server metrics such as load, CPU, memory, d
 
 ---
 
+### ServerChan Example
+
+<details>
+  <summary>Expand/collapse</summary>
+
+- **Simple example:**
+
+  - **Name**: ServerChan
+  - **URL**: `https://sc.ftqq.com/SCUrandomkeys.send?title=Nezha notification&desp=#NEZHA#`
+  - **Request method**: `GET`
+  - **Request type**: default
+  - **Body**: empty
+
+- **Advanced example:**
+
+  - **Name**: ServerChan
+  - **URL**: `https://sc.ftqq.com/SCUrandomkeys.send`
+  - **Request method**: `POST`
+  - **Request type**: `FORM`
+  - **Body**:
+    ```json
+    {
+      "title": "#SERVER.NAME#",
+      "desp": "**#NEZHA#\n\nAverage load: \"#SERVER.LOAD1#\",\"#SERVER.LOAD5#\",\"#SERVER.LOAD15#\"\n\n## [Open Dashboard](https://your-dashboard-domain)\n\n![logo](https://raw.githubusercontent.com/naiba/nezha/master/resource/static/brand.svg)"
+    }
+    ```
+
+  **Notification preview:**
+
+  ![ServerChan notification preview](https://github.com/iilemon/nezhahq.github.io/blob/main/docs/images/photo_2023-03-16_00-22-47a.jpg?raw=true)
+
+</details>
+
+---
+
 ### Telegram Example (Contributed by [@cantoblanco](https://github.com/cantoblanco))
 
 <details>
-  <summary>Expand/Collapse</summary>
+  <summary>Expand/collapse</summary>
 
-#### URL Parameter Setup
+#### Get URL Parameters
 
-1. **Create a Bot**: Use [@BotFather](https://t.me/BotFather) to create a bot and get its token.
-2. **Retrieve User ID**: Use [@userinfobot](https://t.me/userinfobot) to find your user ID.
-3. **Send a Test Message**: Send a message to your bot to activate communication.
+1. **Get bot token**: Chat with [@BotFather](https://t.me/BotFather), send `/newbot` to create a new bot, and get the token.
+2. **Get user ID**: Chat with [@userinfobot](https://t.me/userinfobot) to get your user ID.
+3. **Chat with the bot**: Send a message to the newly created bot first to ensure it can send messages to you.
 
-**Notification Configuration:**
+**Notification configuration:**
 
 - **Name**: Telegram
-- **URL**: `https://api.telegram.org/bot<Your_Bot_Token>/sendMessage?chat_id=<Your_User_ID>&text=#NEZHA#`
-- **Request Method**: GET
-- **Request Type**: Default
-- **Body**: None
+- **URL**: `https://api.telegram.org/bot<your-bot-token>/sendMessage?chat_id=<your-user-id>&text=#NEZHA#`
+- **Request method**: `GET`
+- **Request type**: default
+- **Body**: empty
 
-**Note**: Replace `<Your_Bot_Token>` and `<Your_User_ID>` with actual values.
+**Note**: Replace `<your-bot-token>` and `<your-user-id>` with actual values.
+
+</details>
+
+---
+
+### wxpusher Example
+
+<details>
+  <summary>Expand/collapse</summary>
+
+**Follow your application in advance.**
+
+- **Name**: wxpusher
+- **URL**: `http://wxpusher.zjiecode.com/api/send/message`
+- **Request method**: `POST`
+- **Request type**: `JSON`
+- **Body**:
+  ```json
+  {
+    "appToken": "your appToken",
+    "topicIds": [],
+    "content": "#NEZHA#",
+    "contentType": "1",
+    "uids": ["your uid"]
+  }
+  ```
+
+</details>
+
+---
+
+### Email Notification Example (Using SendCloud, Contributed by [@cantoblanco](https://github.com/cantoblanco), [@erbanku](https://github.com/erbanku))
+
+<details>
+  <summary>Expand/collapse</summary>
+
+**Note**: SendCloud has a daily free email quota. This is only an example.
+
+#### Get URL Parameters
+
+1. **Register an account**:
+  - China SendCloud: Register and log in at [SendCloud](https://www.sendcloud.net/).
+  - International SendCloud: Register and log in at [SendCloud](https://www.aurorasendcloud.com/).
+2. **Get APIUSER and APIKEY**: Get them from account settings.
+3. **Set sender and recipient email**: Customize sender and recipient email addresses.
+
+**Notification configuration:**
+
+- **Name**: Email notification
+- **URL (China version)**:
+  ```
+  https://api.sendcloud.net/apiv2/mail/send?apiUser=<APIUSER>&apiKey=<APIKEY>&from=<sender-email>&fromName=Nezha&to=<recipient-email>&subject=Nezha-Notification&html=#NEZHA#
+  ```
+- **URL (International version)**:
+  ```
+  https://api2.sendcloud.net/api/mail/send?apiUser=<APIUSER>&apiKey=<APIKEY>&from=<sender-email>&fromName=Nezha&to=<recipient-email>&subject=Nezha-Notification&html=#NEZHA#
+  ```
+- **Request method**: `POST`
+- **Request type**: `JSON`
+- **Header**: empty
+- **Body**: empty
+
+**Note**: Replace `<APIUSER>`, `<APIKEY>`, `<sender-email>`, and `<recipient-email>` with actual values.
+
+</details>
+
+---
+
+### DingTalk Group Bot Example
+
+<details>
+  <summary>Expand/collapse</summary>
+
+#### Get URL Parameters
+
+1. **Create a bot**: Add a bot in DingTalk group settings and select custom keyword mode.
+2. **Get Webhook URL**: Obtain it after creation.
+
+**Notification configuration:**
+
+- **Name**: Nezha Monitor Bot
+- **URL**: `https://oapi.dingtalk.com/robot/send?access_token=xxxxxxxxxxxxxxxxx`
+- **Request method**: `POST`
+- **Request type**: `JSON`
+- **Header**:
+  ```json
+  {
+    "Content-Type": "application/json"
+  }
+  ```
+- **Body**:
+  ```json
+  {
+    "msgtype": "text",
+    "text": {
+      "content": "Nezha Monitor:\n#NEZHA#"
+    }
+  }
+  ```
+
+**Note**: Replace `access_token` with your bot token, and the `content` must include your custom keyword.
+
+</details>
+
+---
+
+### WeCom Group Bot Example (Contributed by [@ChowRex](https://github.com/ChowRex))
+
+<details>
+  <summary>Expand/collapse</summary>
+
+#### Configuration Example
+
+- **Name**: WeCom group bot
+- **URL**: `https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=YOUR_BOT_KEY`
+- **Request method**: `POST`
+- **Request type**: `JSON`
+- **Body**:
+  ```json
+  {
+    "msgtype": "markdown",
+    "markdown": {
+      "content": "# Nezha Notification\n\n#NEZHA#\n\n> **Name**: #SERVER.NAME#\n> **IP**: #SERVER.IP#\n> **CPU**: #SERVER.CPU#%\n> **Memory**: #SERVER.MEM#%\n> **Disk**: #SERVER.DISK#%\n"
+    }
+  }
+  ```
+
+**Notification preview:**
+
+![WeCom notification preview](https://user-images.githubusercontent.com/30169860/223605620-eac53ee6-09f9-4583-94fa-9b0cdedba81c.png)
+
+</details>
+
+---
+
+### Feishu Group Bot Example (Contributed by [@eya46](https://github.com/eya46))
+
+<details>
+  <summary>Expand/collapse</summary>
+
+#### Get URL Parameters
+
+1. **Create a bot**: Add a custom bot (Webhook) in Feishu group settings.
+2. **Get Webhook URL**: Obtain it after creation.
+
+**Notification configuration:**
+
+- **Name**: Nezha Dashboard Bot
+- **URL**: `https://open.feishu.cn/open-apis/bot/v2/hook/xxxxxxxxxxxxxxxxx`
+- **Request method**: `POST`
+- **Request type**: `JSON`
+- **Body**:
+  ```json
+  {
+    "msg_type": "text",
+    "content": {
+      "text": "#NEZHA#\n#DATETIME#"
+    }
+  }
+  ```
 
 </details>
 
@@ -130,37 +341,33 @@ Nezha Monitoring supports monitoring server metrics such as load, CPU, memory, d
 ### Matrix Notification Example
 
 <details>
-  <summary>Click to Expand/Collapse</summary>
+  <summary>Expand/collapse</summary>
 
 #### Parameter Description
 
-- **Variable Replacement**: Replace the following variables with actual values:
-  - `$YOUR_HOME_SERVER`: Address of your Matrix server.
-  - `$YOUR_NEZHA_URL`: URL of your Nezha Dashboard.
-  - `$YOUR_MATRIX_USERNAME`: Your Matrix username.
-  - `$YOUR_MATRIX_PASSWD`: Your Matrix password.
-  - `$YOUR_MATRIX_TOKEN`: Matrix access token.
-  - `$ROOM_ID`: ID of the Matrix room where notifications will be sent.
-
----
+- **Variable replacement**: Replace these variables with actual values:
+  - `$YOUR_HOME_SERVER`: Matrix server address
+  - `$YOUR_NEZHA_URL`: Your Nezha Dashboard URL
+  - `$YOUR_MATRIX_USERNAME`: Matrix username
+  - `$YOUR_MATRIX_PASSWD`: Matrix password
+  - `$YOUR_MATRIX_TOKEN`: Matrix access token
+  - `$ROOM_ID`: Matrix room ID
 
 #### Retrieve Access Token
 
-Use the following command to obtain `YOUR_MATRIX_TOKEN`:
+Use this command to get `YOUR_MATRIX_TOKEN`:
 
 ```bash
 curl -XPOST -d '{"type": "m.login.password", "identifier": {"user": "$YOUR_MATRIX_USERNAME", "type": "m.id.user"}, "password": "$YOUR_MATRIX_PASSWD"}' "https://$YOUR_HOME_SERVER/_matrix/client/r0/login"
 ```
 
----
-
 #### Notification Configuration
 
 - **Name**: Matrix
 - **URL**: `https://$YOUR_HOME_SERVER/_matrix/client/r0/rooms/$ROOM_ID/send/m.room.message`
-- **Request Method**: `POST`
-- **Request Type**: `JSON`
-- **Headers**:
+- **Request method**: `POST`
+- **Request type**: `JSON`
+- **Header**:
   ```json
   {
     "Authorization": "Bearer $YOUR_MATRIX_TOKEN"
@@ -176,137 +383,138 @@ curl -XPOST -d '{"type": "m.login.password", "identifier": {"user": "$YOUR_MATRI
   }
   ```
 
----
+**Steps to use**:
 
-### Steps to Use
-
-1. **Replace Variables**: Replace all `$` prefixed variables with your actual values.
-2. **Obtain Token**: Use the command above to retrieve `YOUR_MATRIX_TOKEN`.
-3. **Configure Request**: Fill in the URL, Headers, and Body as described.
-4. **Send Notifications**: The configured notification will be sent to the specified Matrix room.
+1. **Replace variables**: Replace all variables beginning with `$` with your actual values.
+2. **Get token**: Use the command above to get `YOUR_MATRIX_TOKEN`.
+3. **Configure request**: Fill in URL, Header, and Body according to the configuration.
+4. **Send notifications**: After configuration, notifications are sent to the specified Matrix room.
 
 </details>
 
 ---
 
-# Alert Rule Configuration
+## Alert Rule Description
 
-**Before configuring alert rules, set up notification methods and group them into notification groups. Alert rules send notifications at the group level.**
-
----
+**Before configuring alert rules, configure notification methods first, then configure notification groups for notification methods in group settings. Alert rules send notifications by notification group.**
 
 ### Basic Rules
 
-- **`type`**: Select one or more types. All selected types **must be satisfied** to trigger a notification.
-  - **Resource Types**: `cpu`, `gpu`, `memory`, `swap`, `disk`
-  - **Network Types**: `net_in_speed`, `net_out_speed`, `net_all_speed`, `transfer_in`, `transfer_out`, `transfer_all`
-  - **System Types**: `offline`, `load1`, `load5`, `load15`, `process_count`
-  - **Connection Counts**: `tcp_conn_count`, `udp_conn_count`
-  - **Temperature**: `temperature_max` (maximum temperature)
-- **`duration`**: Duration in seconds. Alerts are triggered if the condition persists for this duration with at least 30% of the data satisfying the threshold.
+- **`type`**: Select one or more types. A notification is triggered only when all selected types are satisfied at the same time.
+  - **Resource**: `cpu`, `gpu`, `memory`, `swap`, `disk`
+  - **Network**: `net_in_speed` (inbound speed), `net_out_speed` (outbound speed), `net_all_speed` (bidirectional speed), `transfer_in` (inbound traffic), `transfer_out` (outbound traffic), `transfer_all` (bidirectional traffic)
+  - **System**: `offline` (offline monitoring), `load1`, `load5`, `load15` (load), `process_count` (process count)
+  - **Connections**: `tcp_conn_count`, `udp_conn_count`
+  - **Temperature**: `temperature_max` (maximum temperature value)
+- **`duration`**: Duration in seconds. A notification is sent only when samples exceed the threshold more than 30% of the time within this duration, preventing false positives from fluctuation.
 - **`min` / `max`**:
-  - Bandwidth and traffic are measured in bytes (1KB = 1024B, 1MB = 1024\*1024B).
-  - Memory, disk, and CPU usage are measured as percentages (0-100).
-  - Offline monitoring does not require these fields.
+  - Traffic and speed units are bytes (1KB=1024B, 1MB=1024\*1024B).
+  - Memory, disk, and CPU use percentages (0-100).
+  - Offline monitoring does not need this item.
 - **`cover`**:
-  - `0`: Monitor all servers, exclude specific ones with `ignore`.
-  - `1`: Ignore all servers, include specific ones with `ignore`.
-- **`ignore`**: Specifies servers to exclude or include for monitoring, in the format `{ServerID: true/false}`.
+  - `0`: Monitor all servers. Use `ignore` to ignore specific servers.
+  - `1`: Ignore all servers. Use `ignore` to select specific servers for monitoring.
+- **`ignore`**: Used with `cover` to specify server monitoring strategy, in the format `{server ID: true/false}`.
 
----
+**Examples**:
 
-### Examples
+- **Offline notification**:
 
-#### Offline Notification
-
-- **Name**: Offline Alert
-- **Rule**:
-  ```json
-  [{"type": "offline", "duration": 10}]
-  ```
-- **Enabled**: √
-
-#### CPU and Memory Monitoring
-
-- **Name**: CPU + Memory Alert
-- **Rule**:
-  ```json
-  [
-    {"type": "cpu", "min": 0, "max": 50, "duration": 10},
-    {"type": "memory", "min": 20, "max": 0, "duration": 20}
-  ]
-  ```
-- **Enabled**: √
-
-#### Specific Server Notifications to Groups
-
-**Scenario**: Notify group A when servers 1 and 2 are offline for 10 minutes. Notify group B for servers 3 and 4.
-
-- **Rule for Group A**:
-  - **Name**: Alert for 1, 2
+  - **Name**: Offline notification
   - **Rule**:
     ```json
-    [{"type": "offline", "duration": 600, "cover": 1, "ignore": {"1": true, "2": true}}]
+    [{"type": "offline", "duration": 10}]
     ```
-  - **Notification Group**: A
-  - **Enabled**: √
+  - **Enabled**: checked
 
-- **Rule for Group B**:
-  - **Name**: Alert for 3, 4
+- **CPU and memory monitoring**:
+
+  - **Name**: CPU+Memory
   - **Rule**:
     ```json
-    [{"type": "offline", "duration": 600, "cover": 1, "ignore": {"3": true, "4": true}}]
+    [
+      {"type": "cpu", "min": 0, "max": 50, "duration": 10},
+      {"type": "memory", "min": 20, "max": 0, "duration": 20}
+    ]
     ```
-  - **Notification Group**: B
-  - **Enabled**: √
+  - **Enabled**: checked
 
----
+- **Send notifications for specific servers to specified notification groups**:
 
-### Special Rules: Periodic Traffic Alerts
+  - **Scenario**: Servers 1 and 2 send notifications to notification group A after being offline for 10 minutes; servers 3 and 4 send notifications to notification group B after being offline for 10 minutes.
 
-Useful for monitoring monthly traffic.
+  - **Rule 1 (notification group A)**:
+    - **Name**: Servers 1 and 2 offline notification
+    - **Rule**:
+      ```json
+      [{"type": "offline", "duration": 600, "cover": 1, "ignore": {"1": true, "2": true}}]
+      ```
+    - **Notification group**: A
+    - **Enabled**: checked
+
+  - **Rule 2 (notification group B)**:
+    - **Name**: Servers 3 and 4 offline notification
+    - **Rule**:
+      ```json
+      [{"type": "offline", "duration": 600, "cover": 1, "ignore": {"3": true, "4": true}}]
+      ```
+    - **Notification group**: B
+    - **Enabled**: checked
+
+### Special Rule: Any-Period Traffic Notification
+
+This can be used for monthly traffic monitoring.
 
 - **`type`**:
-  - `transfer_in_cycle`: Periodic inbound traffic.
-  - `transfer_out_cycle`: Periodic outbound traffic.
-  - `transfer_all_cycle`: Combined inbound and outbound traffic.
-- **`cycle_start`**: Start date of the cycle (RFC3339 format, e.g., `2022-01-01T00:00:00+08:00`).
-- **`cycle_interval`**: Cycle interval in units (e.g., 1 month).
-- **`cycle_unit`**: Unit of the cycle (`hour`, `day`, `week`, `month`, `year`).
-- **`min` / `max`, `cover`, `ignore`**: Same as basic rules.
+  - `transfer_in_cycle`: inbound traffic during the cycle
+  - `transfer_out_cycle`: outbound traffic during the cycle
+  - `transfer_all_cycle`: total bidirectional traffic during the cycle
+- **`cycle_start`**: Statistics cycle start date in RFC3339 format, such as `2022-01-01T00:00:00+08:00`.
+- **`cycle_interval`**: Number of statistics cycles, such as every 1 month.
+- **`cycle_unit`**: Statistics cycle unit. Optional values: `hour`, `day`, `week`, `month`, `year`.
+- **`min` / `max`**, `cover`, and `ignore` are the same as basic rules.
+
+**Example**:
+
+- **Monthly traffic over-limit notification**:
+
+  - **Rule**:
+    ```json
+    [
+      {
+        "type": "transfer_out_cycle",
+        "max": 1099511627776,
+        "cycle_start": "2022-01-01T00:00:00+08:00",
+        "cycle_interval": 1,
+        "cycle_unit": "month",
+        "cover": 1,
+        "ignore": {"3": true, "4": true}
+      }
+    ]
+    ```
+
+  - **Description**: A notification is triggered when monthly outbound traffic for servers 3 and 4 exceeds 1TB. The statistics cycle starts on the 1st day of each month.
+
+::: tip
+If you are unsure about alert rules, use these third-party configuration generators to simplify setup. Nezha Monitor does not provide any guarantee for third-party generator functionality:
+
+- [Nezha Rule Generator](https://nz-rule-generator.pages.dev/): suitable for most scenarios.
+- [NEZHA Config Generator](https://nzcfg.pages.dev/): focused on cycle traffic notification rule generation. Select “traffic monitoring code” at the top.
+
+:::
 
 ---
 
-#### Example: Monthly Traffic Alert
+## Notification Trigger Modes
 
-- **Rule**:
-  ```json
-  [
-    {
-      "Type": "transfer_out_cycle",
-      "Max": 1099511627776,
-      "Cycle_start": "2022-01-01T00:00:00+08:00",
-      "Cycle_interval": 1,
-      "Cycle_unit": "month",
-      "Cover": 1,
-      "Ignore": {"3": true, "4": true}
-    }
-  ]
-  ```
-- **Explanation**: Sends an alert when the outbound traffic of servers 3 and 4 exceeds 1TB in a monthly cycle starting on the 1st.
+- **Always**: Each time the status reported by the Agent matches the notification rule, a notification is triggered.
+- **Once**: Only triggers on state changes, such as from normal to abnormal or from abnormal back to normal.
 
 ---
 
-### Notification Trigger Modes
+## Execute Tasks on Notification
 
-- **Always**: Sends notifications whenever the Agent reports a state satisfying the alert rule.
-- **Once**: Sends notifications only when the state changes (e.g., normal to abnormal, or abnormal to normal).
+If you need to execute a specific task while sending notifications, configure:
 
----
-
-### Execute Tasks on Notification
-
-To execute tasks when a notification is triggered:
-
-- **Always Execute**: Executes the specified task when the state changes from "normal" to "alert".
-- **Execute Once**: Executes the specified task when the state changes from "alert" to "normal".
+- **Always execute task**: When notification status changes from “normal” to “abnormal”, execute the specified task. The task must be configured in advance on the Tasks page.
+- **Execute task once**: When notification status changes from “abnormal” back to “normal”, execute the specified task. The task must be configured in advance on the Tasks page.

--- a/docs/en_US/guide/q10.md
+++ b/docs/en_US/guide/q10.md
@@ -1,28 +1,23 @@
 ---
 outline: deep
 ---
+
 # Configuring OIDC Authentication
 
-Modify the contents of `config.yaml` to configure OIDC (OpenID Connect) authentication. OIDC is an authentication layer on top of the OAuth 2.0 protocol, which allows applications to verify the identity of users based on the authentication performed by an Authorization Server. This method is widely used to implement single sign-on for modern applications.
+::: warning
+The original content of this page applied to the v0 OIDC configuration format and does not apply to v1 or later.
+:::
 
-## Configuration Details
+Since v1, the Dashboard no longer uses the old `type: oidc`, `oidcIssuer`, `oidcScopes`, and related fields. Third-party login in the current version is configured through the unified OAuth2 binding structure.
 
-Here is a step-by-step guide to configuring the OIDC settings in your `config.yaml`:
+If your OIDC provider supports standard OAuth2/OIDC endpoints, fill in the new structure described in [Setting Up OAuth 2.0 Binding](/en_US/guide/q14.html):
 
-```yaml
-oauth2:
-  type: oidc  # (Required) Specifies the authentication type as OIDC
-  oidcDisplayName: OIDC  # (Optional, default: OIDC) The name displayed on the login page
-  admin: ""  # (Fill at least one of admin or adminGroups; default: empty) Admin usernames, separated by commas. Users listed here are considered administrators
-  adminGroups: ""  # (Fill at least one of admin or adminGroups; default: empty) Admin groups, separated by commas. Users in these groups are considered administrators. Omit if group management is not used
-  clientid: # (Required) OIDC client ID
-  clientsecret: # (Required) OIDC client secret
-  oidcIssuer: https://auth.example.com/realms/master  # (Required) The issuer URL of the OIDC provider, obtainable from your OIDC provider
-  # oidcLogoutUrl: https://auth.example.com/realms/master/protocol/openid-connect/logout  # (Currently unusable due to a bug)
-  # oidcRegisterUrl: # (Optional) Registration link provided by the OIDC provider
-  oidcScopes: openid,profile,email  # (Optional, default: openid,profile,email) OIDC scopes requested, separated by commas
-  oidcLoginClaim: sub  # (Optional, default: sub) The username field returned by OIDC, can be preferred_username, sub, or email
-  oidcGroupsClaim: groups  # (Required if using adminGroups, default: groups) The user group information field returned by OIDC, can be groups or roles
-  oidcAutoCreate: false  # (Optional, default: false) Whether to automatically create a user if they do not exist
-  oidcAutoLogin: false  # (Optional, default: false) Whether to automatically redirect to the OIDC login page when the path is /login
-```
+- `client_id`
+- `client_secret`
+- `endpoint.auth_url`
+- `endpoint.token_url`
+- `scopes`
+- `user_info_url`
+- `user_id_path`
+
+After configuring and restarting the Dashboard, log in with a local account first, bind the third-party account on the profile page, and then use the OAuth2 button on the login page.

--- a/docs/en_US/guide/q2.md
+++ b/docs/en_US/guide/q2.md
@@ -49,7 +49,8 @@ If the network connection is normal but the Agent is still offline, try disablin
 
 Enable debug mode in the configuration file. Check the Agent's running status and logs using the following command:
 ```bash
-systemctl status nezha-agent-*
+systemctl status 'nezha-agent*'
+journalctl -u 'nezha-agent*' -e --no-pager
 ```
 
 Inspect the logs for error messages to pinpoint the cause.
@@ -64,6 +65,8 @@ Verify if the Agent can successfully connect to the gRPC service:
 ```bash
 curl http://<Your IP or Domain>:<Port>/proto.NezhaService/ -H "Content-Type:application/grpc" -X POST -v
 ```
+
+If the Dashboard entry uses HTTPS, change `http://` in the command to `https://`.
 
 ### Example of a Normal Response:
 ```plain

--- a/docs/en_US/guide/q8.md
+++ b/docs/en_US/guide/q8.md
@@ -1,55 +1,13 @@
 ---
 outline: deep
 ---
-# Cloudflare Access OAuth2 Configuration
-If you encounter issues logging in as an administrator using Github, Gitlab, or Gitee, you may consider switching to Cloudflare Access as the OAuth2 provider.
 
-## Example Configuration:
+# Using Cloudflare Access as an OAuth2 Provider
 
-```yaml
-Oauth2:
-  Admin: 701b9ea6-9f56-48cd-af3e-cbb4bfc1475c
-  ClientID: 3516291f53eca9b4901a01337e41be7dc52f565c8657d08a3fddb2178d13c5bf
-  ClientSecret: 0568b67c7b6d0ed51c663e2fe935683007c28f947a27b7bd47a5ad3d8b56fb67
-  Endpoint: "https://xxxxx.cloudflareaccess.com"
-  Type: cloudflare
-```
+::: warning
+The original content of this page applied to the v0 OAuth2 configuration format and does not apply to v1 or later.
+:::
 
-## Configuration Description:
+Since v1, the Dashboard uses the new OAuth2 configuration structure. Cloudflare Access should also be configured with the new format.
 
-| Parameter             | Retrieval Method                                                                |
-|-----------------------|---------------------------------------------------------------------------------|
-| Admin                 | `My Team` -> `Users` -> `<specific user>` -> `User ID`                          |
-| ClientID/ClientSecret | `Access` -> `Application` -> `Add an Application` <br/> -> `SaaS` -> `OIDC`     |
-| Endpoint              | `Access` -> `Application` -> `Application URL` -> `Only keep the protocol and domain, no path` |
-
-### Setting Up a New SaaS-OIDC Application
-
-Navigate to the Zero Trust Dashboard: [https://one.dash.cloudflare.com/](https://one.dash.cloudflare.com/). Choose or create a new account, then follow these steps:
-
-1. Go to `My Team` -> `Users` -> Click `<specific user>` -> Obtain and save the `User ID`. *(If this is your first time using Zero Trust, the Users list will be empty, and you can skip this step; users will appear after completing a verification.)*
-2. Navigate to `Access` -> `Applications` -> `Add an Application`.
-3. Select `SaaS`. In the `Application` field, enter a custom application name (e.g., `nezha`), select `OIDC`, and then click `Add application`.
-4. For `Scopes`, select `openid`, `email`, `profile`, `groups`.
-5. In `Redirect URLs`, enter your Dashboard Callback URL, such as `https://dashboard.example.com/oauth2/callback`.
-6. Record the `Client ID`, `Client Secret`, and the protocol and domain part of the `Issuer` address, for example, `https://xxxxx.cloudflareaccess.com`.
-7. Edit the Dashboard configuration file (usually located at `/opt/nezha/dashboard/data/config.yaml`), adjust the `OAuth2` settings according to the example configuration, and restart the Dashboard service.
-
-### Identity Verification Strategy Configuration
-
-After setting up the Dashboard, you need to configure identity verification policies in the Zero Trust Dashboard. Navigate to: `Access` -> `Applications` -> `<application name>` -> `Policies`. You can choose from various SSO authentication methods, including email OTP and hardware key verification. For detailed configurations, refer to the [Cloudflare Zero Trust Documentation](https://developers.cloudflare.com/cloudflare-one/).
-
-### Policy Configuration Example (One-time PIN)
-
-Using email OTP as the default verification method:
-
-1. Navigate to `Access` -> `Applications` -> `<application name>` -> `Policies` -> `Add a policy`.
-2. Set a `Policy Name`, for example, `OTP`, and set `Action` to `Allow`.
-3. Under `Configure rules`, add a new `Include` rule. Select `Emails` as the `Selector` and enter your email address in the textbox.
-4. Click `Save policy` to save the configuration.
-
-### Testing the Policy
-
-1. If the configuration is correct, when you visit the Dashboard login interface, it will display as "Log in with Cloudflare Account." Clicking on login will redirect you to the Cloudflare Access login page.
-2. Enter the email address configured previously, click `Send me a code`, and then enter the code received to log in to the Dashboard.
-3. If `User ID` was not specified in `Admin` during previous steps, an error message will be displayed after login: "This user is not an administrator of this site and cannot log in." At this point, you need to go to `My Team` -> `Users`, find the corresponding user, click on the username to get the `User ID`, and enter it into the `Admin` section of the Dashboard configuration file. After restarting the Dashboard service, try logging in again.
+Refer directly to [Setting Up OAuth 2.0 Binding](/en_US/guide/q14.html#cloudflare-access). That document includes the Callback URL, configuration fields, and Cloudflare Access example available in the current version.

--- a/docs/en_US/guide/servers.md
+++ b/docs/en_US/guide/servers.md
@@ -6,101 +6,147 @@ outline: deep
 
 ## Overview
 
-The **Servers** section is responsible for managing Agents, serving as the core foundation for Nezha monitoring and enabling additional functionalities.
+The servers area manages Agents. It is the most basic functional module of Nezha Monitor and the core foundation for other features.
 
 ---
 
 ## Installation Commands
 
-Refer to the [Agent Installation Guide](/en_US/guide/agent.html).  
-The recommended approach is **one-click installation**:
+See [Install Agent](/en_US/guide/agent.html).
+The **one-click installation method** is recommended:
 
-1. Configure the necessary parameters.
-2. Navigate to the servers page in the Dashboard and click the `Installation Command` icon.
-3. Copy the generated installation command and run it on the target server to complete the setup.
+1. Configure the required parameters.
+2. Click the `Installation Command` icon on the Dashboard server page.
+3. Copy the generated installation command and run it on the corresponding server to complete installation.
 
 ---
 
 ## Forced Updates
 
-Agent update behavior is controlled by the following parameters:
+Agent update behavior is controlled by these two parameters:
 
-- `disable-auto-update`: Disables automatic updates.
-- `disable-force-update`: Disables forced updates.
+- `disable-auto-update`: disables automatic updates.
+- `disable-force-update`: disables forced updates.
 
 ### Default Behavior
 
-By default, the Agent updates automatically without manual intervention.
+By default, Agents update automatically without manual intervention.
 
 ### Manual Forced Updates
 
-If automatic updates are disabled, you can manually update the Agent by selecting the target server and executing a **forced update**.  
-**Note**: If the `disable-force-update` parameter is enabled, forced updates will not work.
+If automatic updates have been disabled, select the target servers and execute **Force Update** to update Agents.
+**Note**: When `disable-force-update` is enabled, the force update function is unavailable.
 
 ---
 
 ## Data Column Descriptions
 
-The servers page in the Dashboard displays the following fields:
+Server page columns in the Dashboard:
 
-- **Version**: Displays the current Agent version.
-- **Enable DDNS**: `True` indicates that the Dashboard will automatically update DNS records if the server's IP changes.
-- **Hidden from Guests**: `True` hides the server from guest users in the Dashboard.
+- **Version**: Shows the current Agent version.
+- **Enable DDNS**: When `True`, the Dashboard automatically updates DNS records when the server IP changes.
+- **Hide for Guests**: When `True`, this server is hidden from guests in the panel.
 - **Note**:
   - **Private Note**: Visible only to authenticated users.
-  - **Public Note**: Visible to all users, suitable for displaying general information.
-  - Users can customize note based on their needs. Refer to [Public Note Configuration](#public-note-configuration) for details.
-- **Command Line**: Provides access to WebShell and the Pseudo File Manager. Users can remotely execute commands, manage files, and upload/download files directly through the Dashboard.
-
----
-
-## WebShell
-
-The WebShell feature allows users to remotely access the server's command-line interface through the Dashboard. It supports both Linux and Windows systems.
-
-- **Quick Commands**: Use `Ctrl+Shift+V` to paste commands.
-- **Restrictions**: If the `disable-command-execute` parameter is enabled, the WebShell feature will be disabled.
-- **Connection Issues**: If you encounter connection problems, refer to the [WebSocket Connection Issues Guide](/en_US/guide/q4.html) for troubleshooting.
+  - **Public Note**: Visible to all users and suitable for general information.
+  - Users can customize note content as needed. See [Public Note Configuration](#public-note-configuration).
+- **Command Line**: Provides WebShell and file list features. Users can remotely run commands, manage files, and upload or download files directly through the Dashboard.
 
 ---
 
 ## Edit Configuration
 
-You can edit Agent configurations online by clicking the cog icon in the Action column.
+Click the gear icon in the action column to edit the Agent configuration for a server.
 
-If you edit configurations in batch, no existing configuration will be fetched, and you must manually fill in every field.
+If you use batch edit, the corresponding Agent configuration is not fetched automatically; you need to fill in the configuration items manually.
 
-Agent will apply the new configuration and reload after 10 seconds.
+After a task is sent to the server successfully, the Agent applies the configuration and reloads the service after 10 seconds.
 
 ---
 
-## Pseudo File Manager
+## Batch Move Servers
+
+Administrators can select multiple servers on the server page and transfer them to another user.
+
+Use cases:
+
+- Assign existing servers in a multi-user panel to a new maintainer.
+- Migrate accounts or organize resource ownership.
+- Transfer servers that were automatically registered under the administrator account to a normal user for maintenance.
+
+After transfer, the target user becomes the owner of these servers. Normal users can only see and manage resources under their own account. Before running a batch move, confirm that the target user has been created and can log in normally.
+
+---
+
+## User Frontend Display
+
+The user frontend homepage displays servers by server group. Server groups come from the Dashboard server group configuration, and the group selected by the user on the homepage is saved in the browser session.
+
+The top of the homepage shows total servers, online count, offline count, total traffic, and real-time inbound/outbound rates. Click the total, online, or offline cards to quickly filter the corresponding status.
+
+The server list supports these sorting modes:
+
+- Default order
+- Name
+- Uptime
+- System type
+- CPU
+- Memory
+- Disk
+- Upload rate
+- Download rate
+- Total upload traffic
+- Total download traffic
+
+Except for name sorting, online servers are shown first during sorting. Sort direction can be ascending or descending.
+
+The homepage also provides map, service monitoring panel, and horizontal list layout switches. User choices are saved in browser local storage. You can also force default display through `window.ForceShowMap`, `window.ForceShowServices`, and `window.ForceCardInline` in [Custom Code](/en_US/guide/settings.html#custom-code).
+
+Click a server card to enter the `/server/{id}` detail page. The detail page includes:
+
+- **Details**: Shows CPU, memory, disk, process count, TCP/UDP connection count, inbound/outbound rates, and other metrics, with realtime, 1-day, 7-day, and 30-day charts.
+- **Network**: Shows service-monitoring latency charts that this server participates in, with 1-day, 7-day, and 30-day periods and multi-monitor selection.
+
+Historical charts depend on TSDB. When TSDB is not enabled, non-realtime historical periods are locked in the frontend. Guests can only view realtime and 1-day data; 7-day and 30-day data require login.
+
+---
+
+## Online Terminal
+
+The online terminal (WebShell) allows users to remotely access a server command-line interface through the Dashboard. It supports Linux and Windows systems.
+
+- **Shortcut**: Use `Ctrl+Shift+V` to paste commands.
+- **Limit**: When `disable-command-execute` is enabled, the online terminal is unavailable.
+- **Connection Issues**: If the connection fails, see [WebSocket Connection Failure](/en_US/guide/q4.html).
+
+---
+
+## File List
 
 ::: info
 
-Only support \*nix systems.
+This feature only supports \*nix systems.
 
 :::
 
-Provides a file manager-like interface, allowing you to browse files and download or upload files to the current directory.
-
-Supports **Refresh**, **Go to**, and **Copy path** features to integrate seamlessly with the **WebShell**.
+The file list provides a file-manager-like interface for browsing files and uploading or downloading files in the current directory.
+It supports directory navigation, refresh, and copying the current path, making it convenient to use together with the online terminal.
 
 ---
 
 ## DDNS
 
-After checking the `DDNS` check box, you can fill in the following two fields:
+After checking the `DDNS` checkbox, you can fill in these two fields:
 
-### DDNS configuration ID
+### DDNS Configuration ID
 
-Please refer to the [DDNS](/guide/ddns.html) document to add a basic configuration first, after adding you can see the corresponding `DDNS configuration ID` in the panel.
+Add a basic configuration first according to the [DDNS](/en_US/guide/ddns.html) document. After adding it, you can see the corresponding `DDNS Configuration ID` in the panel.
 
-### Override DDNS domain
+### Override DDNS Domain
 
-You can use this feature to reuse DDNS configuration files without having to copy the Token multiple times.
+This feature lets you reuse a DDNS configuration without copying the token multiple times.
 
-This should be a simple JSON object, you should provide a set of key-value pairs, where the key is the `DDNS configuration ID` wrapped in double quotes, the ID specified here must be specified in the `DDNS configuration ID` field, and the value should be an array of domain names. You can provide more than one domain name, and the Settings here will override the default domain name you set in the DDNS Configuration.
+It should be a simple JSON object. Provide key-value pairs where the key is a `DDNS Configuration ID` wrapped in double quotes. The ID specified here must already be specified in the `DDNS Configuration ID` field. The value should be an array of domains. You can provide multiple domains, and this setting overrides the default domains configured in `DDNS Configuration`.
 
 ```json
 {
@@ -112,13 +158,15 @@ This should be a simple JSON object, you should provide a set of key-value pairs
 
 ## Public Note Configuration
 
-Nezha supports configuring custom public information in the Dashboard for frontend customization.
+Nezha Monitor supports setting public notes for servers in the Dashboard. The default user frontend tries to parse public notes as JSON and display supplemental information such as billing, plan, and route data.
+
+`billingDataMod` and `planDataMod` can be filled in together or separately. Public note content is visible to guests; do not put passwords, tokens, real customer data, or other sensitive information in it.
 
 ---
 
-### Configuration Example (default theme)
+### Configuration Example (Default Theme)
 
-Below is a JSON configuration example for public note:
+Example JSON configuration for public notes:
 
 ```json
 {
@@ -143,28 +191,30 @@ Below is a JSON configuration example for public note:
 
 #### Field Descriptions
 
-1. **Billing Information (`billingDataMod`)**:
+1. **Billing information `billingDataMod`**:
 
-   - **`startDate`**: Start date of the billing period (ISO format).
-   - **`endDate`**: End date of the billing period (ISO format).
-   - **`autoRenewal`**: Automatic renewal status, `1` for enabled.
-   - **`cycle`**: Billing cycle (e.g., `Month`, `Year`).
-   - **`amount`**: Billing amount and currency.
+   - **`startDate`**: Billing start date in ISO time format.
+   - **`endDate`**: Billing end date in ISO time format. If it starts with `0000-00-00`, the frontend displays it as long-term or permanent service.
+   - **`autoRenewal`**: Auto-renewal status. `1` means enabled, and the frontend calculates remaining time together with the cycle.
+   - **`cycle`**: Billing cycle, such as `Month`, `Year`, or localized month/year labels.
+   - **`amount`**: Billing amount and currency. `0` displays as free, `-1` displays as pay-as-you-go, and other values are displayed as written.
 
-2. **Traffic and Network Configuration (`planDataMod`)**:
+2. **Traffic and network configuration `planDataMod`**:
    - **`bandwidth`**: Server bandwidth information.
    - **`trafficVol`**: Traffic quota and cycle.
-   - **`trafficType`**: Traffic type, `1` for inbound only, `2` for both inbound and outbound.
-   - **`IPv4` / `IPv6`**: Number of supported IPv4 or IPv6 addresses.
-   - **`networkRoute`**: Network route information (e.g., AS4837).
-   - **`extra`**: Additional remarks for custom information.
+   - **`trafficType`**: Traffic type field. The current default user frontend parses it but does not directly display it; it can be reserved for custom themes or secondary development.
+   - **`IPv4` / `IPv6`**: When the value is `1`, the frontend displays the corresponding IPv4 / IPv6 label.
+   - **`networkRoute`**: Network route information, such as `AS4837`. Multiple values can be separated by English commas, and the frontend displays them separately.
+   - **`extra`**: Extra note field. Multiple values can be separated by English commas, and the frontend displays them separately.
+
+The current user frontend caches the server's last non-empty public note in browser `sessionStorage`. After modifying or clearing a public note, if the old content is still visible in the current browser session, refresh the page, close and reopen the tab, or clear this site's session storage before checking again.
 
 ---
 
 ::: tip
-**Use Tools for Easy Configuration**  
-If you're unfamiliar with JSON configuration, you can use a third-party generator to quickly create public notes:  
+**Use a tool for easier configuration**
+If you are not familiar with JSON configuration rules, you can use this third-party public note generator to quickly generate a configuration:
 [Public Note Generator](https://nezhainfojson.pages.dev/)
 
-Copy the generated JSON into the corresponding public note section in the Dashboard and save the changes to display the information on the Dashboard front end.
+Copy the generated JSON into the corresponding public note setting in the Dashboard and save it to display the information on the frontend.
 :::

--- a/docs/en_US/guide/services.md
+++ b/docs/en_US/guide/services.md
@@ -4,8 +4,8 @@ outline: deep
 
 # Service Monitoring
 
-**The Service section is where you configure Agents to monitor external websites or servers.**  
-Once a service monitor is set up, you can view the availability results from the past 30 days by clicking the **`Service`** icon on the homepage.
+**The service area is used to configure Agents to monitor external websites or servers.**
+After setting up service monitors, you can click the **`Services`** icon on the homepage to view availability monitoring results from the past 30 days.
 
 ---
 
@@ -13,64 +13,76 @@ Once a service monitor is set up, you can view the availability results from the
 
 ### Add a New Service Monitor
 
-Follow these steps to add a new service monitor:
-
-1. **Access the Admin Panel**  
+To add a new service monitor, follow these steps:
+1. **Open the admin frontend**
    Go to the **`Services`** page and click the **`+`** button to add a new service monitor.
 
-2. **Configure Parameters**  
-   When adding a monitor, fill in the following details:
-   - **Name**: Give the service a custom name.
-   - **Target**: Set the target based on the monitoring type:
-     - `HTTP GET`: Enter a complete URL (including `http://` or `https://`), e.g., `https://example.com`.  
-       **Note**: If the target URL uses `https://`, Nezha Monitoring will also monitor its SSL certificate. Notifications will be triggered for certificate expiration or changes.
-     - `ICMP Ping`: Enter a domain or IP address (without a port number), e.g., `1.1.1.1` or `example.com`.
-     - `TCP Ping`: Enter a domain or IP address with a port number, e.g., `1.1.1.1:80` or `example.com:22`.
-   - **Type**: Choose the monitoring type (`HTTP GET`, `ICMP Ping`, or `TCP Ping`).
-   - **Display in Services**: Choose whether this monitor is visible to guest users (privacy option).
-   - **Interval**: Set the monitoring interval (in seconds).
-   - **Coverage Scope**: Select a rule to determine which Agents will request the target.
-   - **Specific Servers**: Specify which Agents within the coverage scope will perform the monitoring.
-   - **Notification Group ID**: Choose a pre-configured notification method from the **`Notifications`** page. See [Notification Configuration](/guide/notifications.html#flexible-notification-methods) for details.
-   - **Enable Failure Notification**: Optionally enable notifications for target failures (disabled by default).
+2. **Configure parameters**
+   Set the following parameters when adding the monitor:
+   - **Name**: A custom name for this service.
+   - **Target**: Set the target according to the monitor type:
+     - `HTTP GET`: Enter the full URL, including `http://` or `https://`, for example: `https://example.com`.
+       **Note**: If the target URL uses `https://`, Nezha Monitor also monitors the SSL certificate of that URL. Certificate expiration or changes will trigger notifications.
+     - `ICMP Ping`: Enter a domain name or IP address without a port, for example: `1.1.1.1` or `example.com`.
+     - `TCPing`: Enter a domain name or IP address with a port, for example: `1.1.1.1:80` or `example.com:22`.
+   - **Type**: Select the monitor type: `HTTP GET`, `ICMP Ping`, or `TCPing`.
+   - **Show in Services**: Whether to show this monitor to guests. This is a privacy option.
+   - **Interval**: Monitoring interval in seconds.
+   - **Sort**: Display order for service monitors. Higher values are shown first.
+   - **Cover**: Select a rule to decide which Agents request the target.
+   - **Specific Servers**: Specify Agents within the selected cover rule.
+   - **Notification Group ID**: Select notification methods configured on the **`Notifications`** page. See [Notification Method Configuration](/en_US/guide/notifications.html#flexible-notification-methods).
+   - **Enable Failure Notification**: Optionally receive notifications when the target fails. Disabled by default.
 
-3. **Submit the Monitor**  
-   Click the **`Submit`** button to save the configuration. Wait a few moments, then check the homepage for monitoring results.
+3. **Submit the monitor**
+   Click **`Submit`** to save the configuration, then wait a moment and return to the homepage to view monitoring results.
 
 ---
 
 ## Delay Change Notifications
 
-Nezha Monitoring tracks and records the latency between Agents and target servers. When significant latency changes occur, notifications can be sent to help monitor network conditions.
+Nezha Monitor collects and monitors latency between Agents and target servers. When latency changes significantly, it can send notifications to help monitor route status.
 
-- **Enable Delay Notification**: Once enabled, notifications will be sent when latency exceeds the specified range (`Max Latency` or `Min Latency`).
+- **Enable Delay Notification**: After enabling this option, notifications are sent when latency exceeds the configured range, either higher than `Maximum Latency` or lower than `Minimum Latency`.
 
 ---
 
-## Trigger Tasks on Notifications
+## Trigger Tasks on Notification
 
-To execute specific tasks when a service monitor triggers a notification:
-
-1. Check the **`Enable Trigger Tasks`** option.
+If you need to run a specific task when a service monitor triggers a notification:
+1. Check **`Enable Trigger Task`**.
 2. Configure:
-   - **Tasks on Alarm Trigger**: Select the task to execute when an alarm is triggered.
-   - **Tasks on Recovery**: Select the task to execute when the service returns to normal.
+   - **Task triggered by alert**: Select the task to run when the alert is triggered.
+   - **Task triggered after recovery**: Select the task to run after the service recovers.
 
-Tasks must be pre-configured in the **`Tasks`** page before using this feature.
+Set up the task configuration on the Tasks page before using this feature.
 
 ---
 
 ## Network Latency Charts
 
-For `TCP-Ping` and `ICMP-Ping` monitoring types, the Dashboard automatically generates network latency charts:
-- Open the details page of the target server and switch to the **`Network`** tab.
-- View historical network latency trends. Data is based on real-time latency statistics between the Agent and the target server.
+For `TCPing` and `ICMP-Ping` monitors, the Dashboard automatically generates network latency charts:
+- Open the corresponding server detail page and switch to the **`Network`** tab.
+- View historical network latency trends based on real-time latency statistics from the Agent to the target server.
+- You can select 1 day, 7 days, or 30 days. Guests can only view 1 day of data; 7-day and 30-day data require login.
+- If the same server participates in multiple monitors, you can select multiple monitors for comparison. When only one monitor is selected, the chart shows both latency and packet loss.
+- Network charts support peak clipping to reduce the impact of sudden spikes on chart readability. You can enable it by default in frontend custom code with `window.ForcePeakCutEnabled = true`.
+
+---
+
+## User Frontend Display
+
+The service monitoring panel on the user frontend homepage displays public services' availability and latency overview for the past 30 days. Users can click the service button on the homepage to expand or collapse this panel, or set `window.ForceShowServices = true` in [Custom Code](/en_US/guide/settings.html#custom-code) to expand it by default.
+
+If the server returns cycle traffic statistics, the homepage service panel also displays cycle traffic cards. Service monitors are displayed by the **Sort** field in their configuration; higher values are shown first.
+
+When there is no service data to display, the user frontend shows an empty-state message. This usually means service monitoring has not been enabled, services are not set to public display, or the currently selected server group has no related service monitoring data.
 
 ---
 
 ## Manage Monitors
 
 To edit or delete an existing service monitor:
-1. Go to the **`Services`** page in the management panel.
-2. Locate the desired monitor configuration.
-3. Click the edit or delete icon on the right to modify or remove the monitor.
+1. Open the **`Services`** page in the admin frontend.
+2. Find the target monitor configuration.
+3. Click the edit or delete icon on the right to modify or remove it.

--- a/docs/en_US/guide/settings.md
+++ b/docs/en_US/guide/settings.md
@@ -4,141 +4,146 @@ outline: deep
 
 # Settings
 
-**Access the settings page by logging into the admin dashboard and clicking on the avatar → `System Settings`.**
+**After logging in to the admin page, click the avatar → System Settings to open the settings page.**
 
 ---
 
-## Site Name
+## System Configuration
 
-Customize the title of your site for easier identification and management.
+### Site Name
 
----
+Customize the site title here for easier identification and management.
 
-## Language Settings
+### Language Settings
 
 Set the software language, mainly affecting notifications and error messages.
 
-The language of the web interface will also be updated.
+The web interface can also change language in real time.
 
----
+### Custom Code
 
-## Custom Code
+This item is used to add custom styles or scripts to the web interface, such as changing the logo, background image, theme, external links, or analytics code.
 
-This option allows you to add custom styles or script code to the web interface, such as modifying the logo, adjusting the color scheme, adding beautification scripts, or tracking scripts.
+The user frontend reads the following global variables. Set them in custom code with `<script>...</script>`; use `true` / `false` for booleans, not strings.
 
-You can also modify the following global variables to use preset custom features directly:
+- `window.CustomBackgroundImage`: Desktop background image URL.
+- `window.CustomMobileBackgroundImage`: Mobile background image URL. If unset, the desktop background image is used.
+- `window.CustomLogo`: Logo image URL.
+- `window.CustomDesc`: Homepage description text.
+- `window.CustomLinks`: Custom external links. The value must be a JSON string parseable by `JSON.parse`, in the format `[{"name":"GitHub","link":"https://github.com/nezhahq/nezha"}]`.
+- `window.ForceTheme`: Force the default color theme. Value is `"light"` or `"dark"`.
+- `window.ShowNetTransfer`: Whether to show inbound/outbound traffic on server cards.
+- `window.DisableAnimatedMan`: Whether to disable the default animated character illustration.
+- `window.CustomIllustration`: Custom illustration URL. After setting it, it replaces the default illustration, and `window.DisableAnimatedMan` is usually unnecessary.
+- `window.FixedTopServerName`: Whether to pin the top server name.
+- `window.ForceUseSvgFlag`: Whether to force SVG flags.
+- `window.ForceShowServices`: Whether to expand the homepage service monitoring panel by default.
+- `window.ForceCardInline`: Whether to force the horizontal server list layout on non-mobile devices. Mobile devices still use the card layout.
+- `window.ForceShowMap`: Whether to expand the homepage map by default.
+- `window.ForcePeakCutEnabled`: Whether to enable network chart peak clipping by default, reducing the impact of sudden spikes on chart readability.
 
-- User Frontend:
-    1. `window.CustomBackgroundImage`: Custom background image.
-    2. `window.CustomMobileBackgroundImage`: Custom mobile background image.
-    3. `window.CustomLogo`: Custom logo. Requires a URL.
-    4. `window.CustomDesc`: Custom description.
-    5. `window.ShowNetTransfer`: Boolean, whether to display network traffic on cards.
-    6. `window.DisableAnimatedMan`: Boolean, enable/disable animated character illustrations.
-    7. `window.CustomIllustration`: Custom illustration, conflicts with `window.DisableAnimatedMan`.
-    8. `window.FixedTopServerName`: Boolean, whether to fix the top server name.
-    9. `window.CustomLinks`: Custom external links, formatted as `[{\"link\":\"https://github.com/hamster1963/nezha-dash\",\"name\":\"GitHub\"}]`.
-    10. `window.ForceTheme`: Force a default color theme, values are "light" or "dark".
-    11. `window.ForceUseSvgFlag`: Boolean, whether to force the use of SVG flags.
+Example:
 
-- Admin Frontend:
-    1. `window.DisableAnimatedMan`: Boolean, enable/disable animated character illustrations.
+```html
+<script>
+  window.CustomLogo = "https://example.com/logo.png";
+  window.CustomDesc = "My Monitor";
+  window.CustomLinks = JSON.stringify([
+    { name: "GitHub", link: "https://github.com/nezhahq/nezha" }
+  ]);
+  window.ForceTheme = "dark";
+  window.ForceShowServices = true;
+</script>
+```
 
----
+- Admin frontend
+    1. `window.DisableAnimatedMan`: Boolean, turns the animated character illustration on/off.
 
-## Agent connecting address
+### Agent Connecting Address
 
-- This is required for installing **Agent** using the installation command.  
-- Set it to the desired Agent connection address, e.g., `data.example.com:8008`.  
-- For more details, refer to [Agent Installation Prerequisites](/en_US/guide/agent.html#prerequisites).
+- This is required when installing Agents with the one-click script.
+- Set it to the Agent connection address you want to use, for example: `data.example.com:8008`.
+- See [Agent Installation Prerequisites](/en_US/guide/agent.html#prerequisites) for details.
 
----
+### Custom Public DNS Nameservers for DDNS
 
-## Custom Public DNS Nameservers for DDNS
+Used by DDNS to query domain SOA records. If empty, the built-in list is used.
 
-Used to query domain SOA records for the DDNS feature. If left blank, the built-in list will be used.
+### Frontend Real IP Request Header
 
----
+- `CF-Connecting-IP` is a request header used to get the visitor's real IP.
+- When accessing the Dashboard through Cloudflare CDN proxy, enabling this feature lets the origin server identify the visitor's real IP correctly.
+  - **Use**: Security auditing, firewall rules, and logging.
 
-## Frontend Real IP Request Header
+::: danger
+1. **Configure Headers Carefully**
+   Frontend real IP request header configuration affects the built-in WAF (Web Application Firewall).
+   If you do not understand how headers are passed, do not modify this casually. Incorrect configuration may cause IPs to be blocked by the built-in WAF.
 
-- `CF-Connecting-IP` is a header used to identify the visitor's real IP address.  
-- When accessing the Dashboard through a Cloudflare CDN proxy, enabling this feature allows the origin server to correctly recognize the visitor's real IP.  
-  - **Purpose**: Facilitates security audits, firewall rule configuration, and accurate logging.
+2. **Prevent Account Brute Force Attacks**
+   The built-in WAF is designed to prevent local account brute force.
+   - If local accounts have no protection, high-frequency password enumeration attacks may occur, such as 100 password attempts per second.
+   - WAF IP identification depends on correctly configured request headers to block such attacks effectively.
 
-::: danger   
-1. **Be Careful with Header Configuration**  
-   The Frontend Real IP Request Header impacts the proper functioning of the built-in Web Application Firewall (WAF).  
-   If you are unfamiliar with header handling, avoid modifying this setting. Incorrect configuration may result in the IP being blocked by the WAF.
-
-2. **Prevent Account Brute Force Attacks**  
-   The built-in WAF is designed to prevent brute force attacks on local accounts.  
-   - Without protective measures, attackers could attempt high-frequency password enumeration (e.g., 100 attempts per second).  
-   - The WAF relies on accurate IP identification via properly configured headers to block such attacks.
-
-3. **Security Recommendations**  
-   Only enable this feature if you understand the header transmission mechanism. Thoroughly test your configuration after enabling.
+3. **Security Advice**
+   Enable this only after you understand how headers are actually passed, and carefully verify the result.
 :::
 
----
+### Agent Real IP Request Header
 
-## Agent Real IP Request Header
+- `CF-Connecting-IP` is a request header used to get the Agent's real IP.
+- When Agents connect to the Dashboard through Cloudflare CDN proxy, enabling this feature lets the origin server identify the Agent's real IP correctly.
 
-- `CF-Connecting-IP` is a header used to identify the Agent's real IP address.  
-- When Agent connecting the Dashboard through a Cloudflare CDN proxy, enabling this feature allows the origin server to correctly recognize the Agent's real IP.  
+### IP Change Notification
 
----
+This feature sends notifications when a server IP address changes. Configure it as follows:
 
-## IP Change Notification
+#### Configuration Options
 
-This feature sends a notification when a server's IP address changes. Configure it as follows:
+1. **Cover**
+   Select a rule to determine which servers need monitoring.
 
-### Configuration Options
+2. **Specific Servers**
+   Used together with Cover to add exclusions for the selected rule.
 
-1. **Coverage Scope**  
-   Select a rule to determine which servers to monitor for IP changes.
+3. **Send notification to notification group**
+   Select notification methods. Notification methods must be configured in advance on the Notifications page.
 
-2. **Specific Servers**  
-   Use this setting to exclude specific servers from the selected rule.
+4. **Enable**
+   After configuration, check **Enable** to make notifications take effect.
 
-3. **Send Notifications to a Group**  
-   Choose a notification group. (Notification methods must be pre-configured in the `Notifications` page.)
-
-4. **Enable the Feature**  
-   Check the **Enable** option to activate notifications.
-
-5. **Show Full IP Address in Notifications**  
-   By default, IP change notifications mask full IP addresses.  
-   To display full IPs, enable this option.
+5. **Show full IP address in notification**
+   By default, IP change notifications hide the full IP address.
+   Check this option if you need to show the complete IP address.
 
 ---
 
 ## User Management
 
-This tab allows you to add multiple users to the dashboard.  
+This tab allows adding multiple users to the Dashboard.
 
-For details, refer to [Multi-User](/en_US/guide/user.html).
+See [Multi-User](/en_US/guide/user.html) for details.
 
 ---
 
 ## Online Users
 
-View information about visitors/users currently connected to the frontend, including **IP** and **connection time**, with the ability to manually block users.
+View current guests / users connected to the frontend, including **IP** and **connection time**, and manually block users.
 
 ---
 
 ## Web Application Firewall
 
-View current blocked entries with useful information:
+You can view current block entries and related useful information:
 
-- **IP**: The IP of the blocked user.
-- **Block Identifier**: The identifier for the resource attacked by the blocked user. Typically a user ID, but in special cases:
-  1. Attempting to crack a gRPC connection key;
-  2. Attempting to crack an API token;
-  3. Attempting to log into a nonexistent user;
-  4. Manual blocking (via the "Online Users" page).
-- **Count**: The number of times this block entry has been triggered. Higher counts result in longer block durations.
-- **Block Reason**: The reason for the last block on this entry.
-- **Ban Time**: The time of the last block on this entry.
+- **IP**: The blocked user's IP.
+- **Block ID**: The resource identifier the blocked user attempted to attack. Together with IP, it identifies a block entry. Usually this is a user ID, but there are these special cases:
+  1. Attempting to brute force a gRPC connection secret;
+  2. Attempting to brute force an API Token;
+  3. Attempting to log in to a nonexistent user;
+  4. Manual block through the Online Users page.
+- **Count**: Number of times this entry has been blocked. Higher counts result in longer block times.
+- **Reason**: The reason for the latest block on this entry.
+- **Time**: The latest block time for this entry.
 
-If the current user is an administrator, they can manually delete block entries.
+If the current user is an administrator, block entries can be deleted manually.


### PR DESCRIPTION
## Summary\n- Syncs English documentation with the current Chinese documentation after the v1 code-diff refresh.\n- Rewrites stale English API, notification, server, service, settings, login/OAuth FAQ, NAT, Agent, and configuration pages to match the Chinese content and current frontend behavior.\n- Keeps English TSDB and connection-secret guidance aligned with the already-merged Chinese source.\n\n## Test Plan\n- git diff --check\n- npm run build