### PR TITLE
docs: add API token and MCP usage docs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -186,6 +186,7 @@ function getGuideSidebarZhCN() {
         { text: '设置', link: '/guide/settings.html' },
         { text: '个人信息', link: '/guide/profile.html' },
         { text: 'API 接口', link: '/guide/api.html' },
+        { text: 'MCP', link: '/guide/mcp.html' },
         { text: '分组', link: '/guide/group.html' },
         { text: '多用户', link: '/guide/user.html' }
       ],
@@ -270,6 +271,7 @@ function getGuideSidebarEnUS() {
         { text: 'Settings', link: '/en_US/guide/settings.html' },
         { text: 'Profile', link: '/en_US/guide/profile.html' },
         { text: 'API Interface', link: '/en_US/guide/api.html' },
+        { text: 'MCP', link: '/en_US/guide/mcp.html' },
         { text: 'Grouping', link: '/en_US/guide/group.html' },
         { text: 'Multi-User', link: '/en_US/guide/user.html' },
       ]

--- a/docs/configuration/dashboard.md
+++ b/docs/configuration/dashboard.md
@@ -56,6 +56,13 @@ outline: deep
   - 指定 Agent 连接 Dashboard 的真实 IP 请求头，例如 `X-Real-Ip`。
   - 如果选项值为 `NZ::Use-Peer-IP`，Dashboard 将会直接使用连接 IP，不再需要上层应用传递请求头。
 
+- ##### **`enable_mcp`**
+
+  - 布尔值，是否启用 Dashboard 内置的 MCP (Model Context Protocol) HTTP 入口。
+  - 默认关闭。启用后，客户端可通过 `POST /mcp` 使用 API Token 调用 MCP 工具；该入口不接受 JWT。
+  - 从开启切换为关闭时，Dashboard 会触发 kill switch，清理 MCP 文件传输临时 URL、撤销 MCP 传输流并取消正在执行的 MCP RPC。
+  - API Token 的 scope 与使用方法详见 [API 接口](/guide/api.html#api-token-pat)。
+
 - ##### **`user_template / admin_template`**
 
   - 默认使用的前端主题。
@@ -98,13 +105,6 @@ outline: deep
   - 布尔值，通知是否发送原始 IP。
   - 默认为 `false`，即发送脱敏后的 IP（例如 1.\*\*.1）。
 
-- ##### **`enable_mcp`**
-
-  - 布尔值，是否启用 MCP 入口，默认为关闭。
-  - 启用后 Dashboard 会接受 `POST /mcp` 请求；该入口只接受 PAT，不接受 JWT。认证和权限说明见 [API 接口 - MCP 接入](/guide/api.html#mcp-%E6%8E%A5%E5%85%A5)。
-  - 启用前应先检查 API Token 的 scope 和服务器白名单，只给 MCP 客户端授予最小权限。
-  - 关闭该选项会触发 MCP kill switch：新的 MCP 请求会被拒绝，正在进行的 MCP 调用和临时上传 / 下载地址也会被中断或清理。
-
 - ##### **`enable_ip_change_notification`**
 
   - 布尔值，是否启用 IP 变更通知。
@@ -116,7 +116,8 @@ outline: deep
 - ##### **`cover`**
 
   - 整数，指定 IP 变更通知的覆盖范围。
-  - `0` 为覆盖全部，`1` 为忽略全部。
+  - `1` 为覆盖全部，`ignored_ip_notification` 中的服务器会被排除。
+  - `2` 为忽略全部，只监控 `ignored_ip_notification` 中的服务器。
 
 - ##### **`ignored_ip_notification`**
 

--- a/docs/en_US/configuration/dashboard.md
+++ b/docs/en_US/configuration/dashboard.md
@@ -56,6 +56,13 @@ Dashboard configuration is in YAML format, where items marked with \* can only b
   - Specifies Agent's real IP request header for the Dashboard, such as `X-Real-Ip`.
   - If the option value is `NZ::Use-Peer-IP`, Dashboard will directly use the connection IP, and no longer need the upper-layer application to pass the request header.
 
+- ##### **`enable_mcp`**
+
+  - Boolean value, whether to enable the Dashboard's built-in MCP (Model Context Protocol) HTTP endpoint.
+  - Disabled by default. When enabled, clients can call MCP tools through `POST /mcp` with an API Token; this endpoint does not accept JWT.
+  - When switching from enabled to disabled, the Dashboard fires a kill switch that removes MCP file-transfer temporary URLs, revokes MCP transfer streams, and cancels in-flight MCP RPC calls.
+  - For API Token scopes and usage, see [API Interface](/en_US/guide/api.html#api-token-pat).
+
 - ##### **`user_template / admin_template`**
 
   - Default frontend theme used.
@@ -98,13 +105,6 @@ Dashboard configuration is in YAML format, where items marked with \* can only b
   - Boolean value, whether the notification sends the original IP.
   - The default is `false`, that is, send the desensitized IP (such as 1.\*\*.1).
 
-- ##### **`enable_mcp`**
-
-  - Boolean value, whether to enable the MCP endpoint. It is disabled by default.
-  - After enabling it, Dashboard accepts `POST /mcp` requests. This endpoint accepts PAT only, not JWT. See [API Interface - MCP Access](/en_US/guide/api.html#mcp-access) for authentication and permission details.
-  - Before enabling it, review API token scopes and server whitelists, and grant only the minimum permissions required by each MCP client.
-  - Disabling this option triggers the MCP kill switch: new MCP requests are rejected, and in-flight MCP calls plus temporary upload / download URLs are interrupted or cleaned up.
-
 - ##### **`enable_ip_change_notification`**
 
   - Boolean value, whether to enable IP change notification.
@@ -116,7 +116,8 @@ Dashboard configuration is in YAML format, where items marked with \* can only b
 - ##### **`cover`**
 
   - Integer, specifies the coverage of IP change notification.
-  - `0` is full coverage, `1` is ignore all.
+  - `1` means full coverage, excluding the servers listed in `ignored_ip_notification`.
+  - `2` means ignore all, monitoring only the servers listed in `ignored_ip_notification`.
 
 - ##### **`ignored_ip_notification`**
 

--- a/docs/en_US/guide/api.md
+++ b/docs/en_US/guide/api.md
@@ -161,6 +161,98 @@ Some read-only APIs support guest access, but they are limited by site configura
 - If a server is hidden from guests, guests cannot access that server's data.
 - In service history and server metrics APIs, guests can only query `1d` period data.
 
+### API Token (PAT)
+
+An API Token is another authentication method for the same `/api/v1` REST API. It is also a PAT (Personal Access Token). It uses the same `Authorization: Bearer ...` header as the JWT returned by login, and it uses the same response format and routes below. The difference is that JWT is for browser login sessions, while API Tokens are for scripts, automation tools, and MCP clients.
+
+Plaintext tokens always start with `nzp_`. The Dashboard stores only a hash. The plaintext token is shown once after creation; after closing the dialog, you cannot reveal it again and must create a new one.
+
+Log in to the admin frontend, open **Settings > API Tokens**, then click **Create API Token**. Fill in:
+
+| Field | Description |
+| --- | --- |
+| Name | A human-readable purpose, for example `homepage-readonly` or `mcp-maintenance`. Maximum 128 characters. |
+| Scopes | Which resources and actions the token can call. At least one scope is required. |
+| Server IDs | Optional server ID allowlist, separated by commas, for example `1,2,3`. Leave it empty to add no extra server restriction; the user's own permissions still apply. |
+| Expires in days | Optional expiry in days. The frontend defaults to `90`; blank or `0` means never expires. Maximum 3650 days. |
+
+Normal users can create, list, and revoke their own tokens. Administrators use the same page for their own tokens, and only administrators can issue admin scopes such as `nezha:admin:*` or `nezha:*`.
+
+REST API calls use the same header as JWT:
+
+```http
+Authorization: Bearer nzp_xxxxxxxxxxxxxxxxxxxx
+```
+
+API Tokens are controlled by `nezha:{resource}:{verb}` scopes and only narrow the current user's original permissions. Even if a token has a scope, it still cannot bypass the user's own server, administrator, or resource ownership restrictions. When creating a token, you can also fill in a server ID allowlist; leaving it empty means there is no additional server restriction.
+
+Common errors:
+
+| Status | Meaning |
+| --- | --- |
+| `401 Unauthorized` | The token is invalid, expired, owned by a missing user, or the `Authorization` header is malformed. |
+| `403 Forbidden` | The token is valid, but it lacks the required scope, the server is outside the allowlist, the user has no permission for the server, or the endpoint explicitly rejects API Tokens. |
+
+Common scopes:
+
+| Scope | Description |
+| --- | --- |
+| `nezha:inventory:read` | Read the server inventory, server groups, and real-time server status stream |
+| `nezha:inventory:delete` | Delete servers and server groups |
+| `nezha:server:read` | Read known server details, metrics, service status, file lists, and file contents |
+| `nezha:server:write` | Modify servers, push configuration, force updates, move servers, and write files |
+| `nezha:server:delete` | Delete files on servers |
+| `nezha:server:exec` | Open online terminals and run commands |
+| `nezha:service:read/write/delete` | Read, create/edit, or delete service monitors |
+| `nezha:alertrule:read/write/delete` | Read, create/edit, or delete alert rules |
+| `nezha:cron:read/write/delete/exec` | Read, create/edit, delete, or manually trigger scheduled tasks |
+| `nezha:ddns:read/write/delete` | Read, create/edit, or delete DDNS profiles |
+| `nezha:nat:read/write/delete` | Read, create/edit, or delete NAT rules |
+| `nezha:notification:read/write/delete` | Read, create/edit, or delete notification methods |
+| `nezha:notification-group:read/write/delete` | Read, create/edit, or delete notification groups |
+| `nezha:transfer:read/write/delete` | Read, cancel/retry, or delete server transfer records |
+| `nezha:<resource>:*` | All actions on one resource, for example `nezha:server:*` |
+| `nezha:admin:*` | User, WAF, settings, online-user, and other admin APIs; admin only |
+| `nezha:*` | Full access; admin only |
+
+`inventory` and `server` are separate resource domains. `inventory` controls which machine records can be listed or deleted, while `server` controls runtime operations on known servers. For example, a token with only `nezha:server:exec` can run commands on an allowed server, but cannot enumerate the server list; listing servers also requires `nezha:inventory:read`.
+
+Common REST route scope mapping:
+
+| Route | Required API Token scope |
+| --- | --- |
+| `GET /api/v1/server`, `GET /api/v1/ws/server`, `GET /api/v1/server-group` | `nezha:inventory:read` |
+| `POST /api/v1/batch-delete/server`, `POST /api/v1/batch-delete/server-group` | `nezha:inventory:delete` |
+| `PATCH /api/v1/server/{id}`, `GET /api/v1/server/config/{id}`, `POST /api/v1/server/config`, `POST /api/v1/batch-move/server`, `POST /api/v1/force-update/server` | `nezha:server:write` |
+| `POST /api/v1/file`, `GET /api/v1/ws/file/{id}` | Requires all of `nezha:server:read`, `nezha:server:write`, and `nezha:server:delete` |
+| `GET /api/v1/transfer`, `GET /api/v1/ws/transfer` | `nezha:transfer:read` |
+| `POST /api/v1/transfer/{id}/cancel`, `POST /api/v1/transfer/{id}/retry` | `nezha:transfer:write` |
+| `GET/POST/PATCH/DELETE` resource management APIs | The matching resource `read`, `write`, or `delete` scope |
+| `/api/v1/user`, `/api/v1/waf`, `/api/v1/online-user`, `PATCH /api/v1/setting`, `POST /api/v1/maintenance` | `nezha:admin:*` or `nezha:*`, and the calling user must be an administrator |
+
+Common scope sets:
+
+| Scenario | Recommended scopes |
+| --- | --- |
+| External dashboard showing only the server inventory | `nezha:inventory:read` |
+| External dashboard reading server details and metrics | `nezha:inventory:read`, `nezha:server:read` |
+| MCP client that lists servers and reads small files | `nezha:inventory:read`, `nezha:server:read` |
+| MCP client that runs maintenance commands | `nezha:inventory:read`, `nezha:server:read`, `nezha:server:exec`, plus a server ID allowlist |
+| MCP client that writes or uploads files | `nezha:server:read`, `nezha:server:write`, plus a server ID allowlist |
+| CI/CD job that only triggers selected cron tasks | `nezha:cron:read`, `nezha:cron:exec` |
+| Operations script managing service monitors | `nezha:service:read`, `nezha:service:write`, and add `nezha:service:delete` only if deletion is needed |
+| Admin automation for system settings | `nezha:admin:*`, available only to administrator tokens |
+
+If the token is for one or a few servers, always set the `Server IDs` allowlist. That way, even broad scopes can only act on those servers.
+
+Legacy `mcp:*` scopes are no longer used as runtime permissions. When creating a token, `mcp:server:read`, `mcp:server:exec`, and `mcp:fs:read` are rewritten to the corresponding `nezha:*` scopes for compatibility; `mcp:fs:write`, `mcp:fs:delete`, and `mcp:*` are rejected. During startup migration, dangerous legacy scopes left in the database are cleaned up, and tokens with no scopes left after cleanup are deleted.
+
+::: warning
+API Tokens cannot call account self-management APIs, such as `/api/v1/profile`, `/api/v1/refresh-token`, `/api/v1/oauth2/{provider}/unbind`, and `/api/v1/api-tokens`. These APIs only accept the JWT produced by browser login.
+:::
+
+In **Settings > API Tokens**, click **Revoke** to revoke a token. After revocation, new requests fail immediately. Long-lived connections using that token are cancelled, including real-time server status streams, transfer streams, online terminals, file manager connections, in-flight MCP `tools/call` requests, file upload/download transfers, and temporary transfer URLs.
+
 ---
 
 ## MCP Access
@@ -449,6 +541,53 @@ Before writing management automation scripts, test them in a staging environment
 
 ---
 
+## MCP Endpoint
+
+The Dashboard includes an MCP (Model Context Protocol) HTTP endpoint for automation clients and LLM tool calls:
+
+For client configuration, tool argument examples, and file transfer details, see the [MCP guide](/en_US/guide/mcp.html).
+
+```http
+POST /mcp
+Authorization: Bearer nzp_xxxxxxxxxxxxxxxxxxxx
+Content-Type: application/json
+```
+
+Enable `enable_mcp` in the Dashboard configuration or admin frontend before using it. This endpoint only accepts API Tokens and does not accept JWT; `GET /mcp` and `DELETE /mcp` return 405.
+
+The current implementation supports Streamable HTTP request/response over POST and does not provide SSE sessions. The JSON-RPC request body is capped at 8 MiB, and each token is rate limited to about 10 requests per second and 120 requests per minute by default. Common JSON-RPC methods:
+
+- `initialize`
+- `tools/list`
+- `tools/call`
+- `notifications/initialized`
+- `ping`
+
+`tools/list` returns both `inputSchema` and `outputSchema` for each tool. On successful `tools/call`, structured data is returned in `structuredContent` and the same result is also provided as JSON text in `content[0].text`. On tool errors, the response only includes `isError: true` and text error content, so strict MCP clients do not validate an error object against the success output schema.
+
+Registered MCP tools and required scopes:
+
+| Tool | Required scope |
+| --- | --- |
+| `meta.whoami` | Any valid API Token |
+| `server.list` | `nezha:inventory:read` |
+| `server.get` | `nezha:server:read` |
+| `server.exec` | `nezha:server:exec` |
+| `fs.list`, `fs.read`, `fs.download_url` | `nezha:server:read` |
+| `fs.write`, `fs.upload_url` | `nezha:server:write` |
+| `fs.delete` | `nezha:server:delete` |
+
+MCP tools that call the Agent require the target Agent version to be at least `v2.1.0`. `server.exec` is a non-interactive one-shot command, does not allocate a PTY, defaults to a 30-second timeout, and has a hard `timeout_seconds` limit of 300 seconds. If you need shell syntax such as pipes or redirection, explicitly use `cmd: "sh"` and `args: ["-c", "..."]`.
+
+File tools are split into two groups:
+
+- `fs.read` / `fs.write` are suitable for small files or ranged reads and writes. `fs.read` returns up to about 1 MiB by default and supports `offset`, `length`, and `encoding: "utf8" | "base64"`.
+- `fs.download_url` / `fs.upload_url` issue one-time temporary URLs through `GET /mcp/download/{token}` or `POST /mcp/upload/{token}` for Dashboard-to-Agent IOStream transfers. The hard per-file limit is 100 MiB, and `ttl_seconds` ranges from 30 to 600 seconds. Uploads must send `Content-Length`; you can append `sha256=<64 hex chars>` to the URL for end-to-end verification. `fs.upload_url` also supports `mode`, `create_dirs`, and `if_match_sha256`.
+
+MCP calls are also limited by the API Token's server ID allowlist and the user's original permissions. Temporary upload/download URLs re-check the token, scope, server allowlist, and server ownership when used. When the token is revoked or `enable_mcp` is disabled, the Dashboard revokes MCP transfer streams, removes temporary URLs, and cancels in-flight MCP RPC calls.
+
+---
+
 ## Usage Examples
 
 ### Get Server List
@@ -457,7 +596,7 @@ Before writing management automation scripts, test them in a staging environment
 import requests
 
 base_url = "https://nezha.example.com"
-token = "JWT_TOKEN"
+token = "JWT_TOKEN_OR_NZP_API_TOKEN"
 
 response = requests.get(
     f"{base_url}/api/v1/server",

--- a/docs/en_US/guide/mcp.md
+++ b/docs/en_US/guide/mcp.md
@@ -1,0 +1,422 @@
+---
+outline: deep
+---
+
+# MCP Guide
+
+The Dashboard includes an MCP (Model Context Protocol) HTTP endpoint for automation clients and LLM tool clients. Clients can list servers, read server details, run one-shot commands, read and write files, and mint temporary upload/download URLs for larger files.
+
+MCP is disabled by default. Enable it in the Dashboard configuration file or admin settings before use:
+
+```yaml
+enable_mcp: true
+```
+
+After enabling it, the endpoint is:
+
+```http
+POST /mcp
+Authorization: Bearer nzp_xxxxxxxxxxxxxxxxxxxx
+Content-Type: application/json
+```
+
+`/mcp` only accepts API Tokens. It does not accept browser-login JWT. To create an `nzp_` token, choose scopes, and set a server allowlist, read [API Interface: API Token (PAT)](/en_US/guide/api.html#api-token-pat) first.
+
+---
+
+## Protocol Behavior
+
+The current implementation supports MCP Streamable HTTP request/response over POST. It does not provide a standalone SSE session:
+
+- `POST /mcp`: JSON-RPC request endpoint.
+- `GET /mcp`: returns `405 Method Not Allowed`.
+- `DELETE /mcp`: returns `405 Method Not Allowed`.
+
+Supported JSON-RPC methods:
+
+| Method | Description |
+| --- | --- |
+| `initialize` | Initializes the MCP session and returns protocol version, capabilities, and server info. |
+| `notifications/initialized` | Initialization-complete notification; without an `id`, it returns `202 Accepted`. |
+| `ping` | Heartbeat; with an `id`, it returns an empty result. |
+| `tools/list` | Lists tools, including each tool's `inputSchema` and `outputSchema`. |
+| `tools/call` | Calls a specific tool. |
+
+The request body limit is 8 MiB. Each token is rate limited to about 10 requests per second and 120 requests per minute by default. When the limit is exceeded, regular JSON-RPC methods return 429; `tools/call` returns an MCP tool error with `isError: true`.
+
+On successful `tools/call`, structured data is returned in `structuredContent`, and the same result is also provided as JSON text in `content[0].text`. On tool failure, the response only includes `isError: true` and text error content, without the success-result schema, so strict MCP clients do not validate an error object as if it were a success result.
+
+---
+
+## Client Configuration Example
+
+Different MCP clients use different configuration field names. For clients that support a Streamable HTTP URL and custom headers, use this shape:
+
+```json
+{
+  "mcpServers": {
+    "nezha": {
+      "url": "https://nezha.example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer nzp_xxxxxxxxxxxxxxxxxxxx"
+      }
+    }
+  }
+}
+```
+
+If your client requires an explicit transport, use HTTP or streamable-http according to that client's documentation. Do not use browser-login JWT, cookies, or OAuth browser sessions for `/mcp`.
+
+---
+
+## Simple Use Cases
+
+These examples describe common user-facing workflows. In most MCP clients, you do not need to write JSON-RPC by hand; ask the client to perform the task and let it call the matching tools.
+
+### Check Which Servers Are Online
+
+You can ask your MCP client: "List the online servers and show the status of one server." The client will usually call `server.list` to find visible servers, then call `server.get` for the target server's status, system information, and GeoIP snapshot. The token needs at least `nezha:inventory:read` and `nezha:server:read`.
+
+### Run a One-Off Inspection Command
+
+You can ask the client to run a non-interactive inspection command on a selected server, such as checking disk usage, load, or service status. The tool is `server.exec`, and it requires `nezha:server:exec`. For these tokens, set a server ID allowlist so the token can only operate on explicitly approved servers.
+
+### Read Logs or Config Files
+
+When you want AI help with nginx, Caddy, or application logs, use `fs.list` to browse directories and `fs.read` to read a small log section or config file. The token needs `nezha:server:read`. For large logs, read ranges instead of returning the whole file at once.
+
+### Update a Small Config File
+
+To change a small config snippet, write a temporary script, or generate a diagnostic file, use `fs.write`; if your client is better at uploading a local file first, use `fs.upload_url`. These operations require `nezha:server:write`. Use `if_match_sha256` to avoid overwriting a file that someone else changed, and set a server ID allowlist for the token.
+
+### Transfer Larger Files
+
+For log bundles, backup snippets, or build artifacts, do not put file bytes into the JSON-RPC body. Use `fs.download_url` or `fs.upload_url` to mint a one-time HTTP URL, then transfer the file with a regular HTTP client. Each file is capped at 100 MiB, each URL can be used only once, and URLs are invalidated when they expire, the token is revoked, or MCP is disabled.
+
+---
+
+## Tools and Permissions
+
+MCP tools are limited by three layers:
+
+1. The API Token must be valid and unexpired.
+2. The API Token must contain the tool's required scope.
+3. The target server must be in the token's server ID allowlist, and the owner user must have permission for that server.
+
+Registered tools:
+
+| Tool | Required scope | Purpose |
+| --- | --- | --- |
+| `meta.whoami` | Any valid API Token | Returns current user ID, admin status, token ID, token name, scopes, and server allowlist. |
+| `server.list` | `nezha:inventory:read` | Lists minimal metadata for servers visible to the token. |
+| `server.get` | `nezha:server:read` | Reads Host/State/GeoIP snapshot for one server. |
+| `server.exec` | `nezha:server:exec` | Runs a non-interactive one-shot command on the target server. |
+| `fs.list` | `nezha:server:read` | Lists a directory. |
+| `fs.read` | `nezha:server:read` | Reads file content, suitable for small files or ranged reads. |
+| `fs.write` | `nezha:server:write` | Atomically writes a file. |
+| `fs.delete` | `nezha:server:delete` | Deletes a file or directory. |
+| `fs.download_url` | `nezha:server:read` | Mints a one-time HTTP download URL for files up to 100 MiB. |
+| `fs.upload_url` | `nezha:server:write` | Mints a one-time HTTP upload URL for files up to 100 MiB. |
+
+Tools that call the Agent require the target Agent version to be at least `v2.1.0`. Agents reporting either `2.1.0` or `v2.1.0` are accepted; older versions return an unsupported-MCP tool error.
+
+---
+
+## Call Examples
+
+### Initialize
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2024-11-05",
+    "capabilities": {},
+    "clientInfo": {
+      "name": "my-client",
+      "version": "1.0.0"
+    }
+  }
+}
+```
+
+### Inspect the Current Token
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "meta.whoami",
+    "arguments": {}
+  }
+}
+```
+
+### List Online Servers
+
+Requires `nezha:inventory:read`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "tools/call",
+  "params": {
+    "name": "server.list",
+    "arguments": {
+      "online_only": true
+    }
+  }
+}
+```
+
+### Read Server Details
+
+Requires `nezha:server:read`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "tools/call",
+  "params": {
+    "name": "server.get",
+    "arguments": {
+      "server_id": 1
+    }
+  }
+}
+```
+
+### Run a Command
+
+Requires `nezha:server:exec`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "method": "tools/call",
+  "params": {
+    "name": "server.exec",
+    "arguments": {
+      "server_id": 1,
+      "cmd": "uname",
+      "args": ["-a"],
+      "timeout_seconds": 30,
+      "max_output_bytes": 65536
+    }
+  }
+}
+```
+
+`server.exec` is a non-interactive one-shot command:
+
+- It does not allocate a PTY.
+- The default timeout is 30 seconds.
+- `timeout_seconds` is capped at 300 seconds.
+- stdout/stderr default to about 64 KiB each, and can be adjusted with `max_output_bytes`, subject to the Agent hard limit.
+- For shell features such as pipes, redirection, or variable expansion, explicitly call a shell:
+
+```json
+{
+  "server_id": 1,
+  "cmd": "sh",
+  "args": ["-c", "df -h | grep /data"],
+  "timeout_seconds": 30
+}
+```
+
+### List a Directory
+
+Requires `nezha:server:read`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 6,
+  "method": "tools/call",
+  "params": {
+    "name": "fs.list",
+    "arguments": {
+      "server_id": 1,
+      "path": "/var/log",
+      "show_hidden": false
+    }
+  }
+}
+```
+
+### Read a File
+
+Requires `nezha:server:read`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "method": "tools/call",
+  "params": {
+    "name": "fs.read",
+    "arguments": {
+      "server_id": 1,
+      "path": "/etc/hostname",
+      "offset": 0,
+      "length": 4096,
+      "encoding": "utf8"
+    }
+  }
+}
+```
+
+`fs.read` is intended for small files or ranged reads. It returns up to about 1 MiB by default. `encoding` can be `utf8` or `base64`.
+
+### Write a File
+
+Requires `nezha:server:write`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 8,
+  "method": "tools/call",
+  "params": {
+    "name": "fs.write",
+    "arguments": {
+      "server_id": 1,
+      "path": "/tmp/nezha-note.txt",
+      "content": "hello from nezha mcp\n",
+      "encoding": "utf8",
+      "mode": "0644",
+      "create_dirs": true
+    }
+  }
+}
+```
+
+Use `if_match_sha256` as an optimistic lock to avoid overwriting a file that changed.
+
+### Delete a File or Directory
+
+Requires `nezha:server:delete`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 9,
+  "method": "tools/call",
+  "params": {
+    "name": "fs.delete",
+    "arguments": {
+      "server_id": 1,
+      "path": "/tmp/nezha-note.txt",
+      "recursive": false
+    }
+  }
+}
+```
+
+Set `recursive: true` when deleting a non-empty directory.
+
+---
+
+## Large File Upload and Download
+
+`fs.download_url` and `fs.upload_url` first mint a one-time temporary URL through MCP, then transfer the file through a regular HTTP client. File bytes do not go into the MCP JSON-RPC body, so these tools are better for larger files.
+
+Limits and behavior:
+
+- The default URL TTL is 300 seconds.
+- The default TTL is 300 seconds. The tool schema recommends `ttl_seconds` from 30 to 600 seconds, and the server caps values above 600 to 600.
+- Each URL can be used only once and is invalidated immediately after use.
+- Each file is capped at 100 MiB.
+- Each transfer is capped at 10 minutes.
+- Temporary URL usage revalidates `enable_mcp`, token, scope, server allowlist, and user server permission.
+- If the token is revoked or an administrator disables `enable_mcp`, unused URLs and in-flight transfers are revoked.
+
+### Download URL
+
+Requires `nezha:server:read`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 10,
+  "method": "tools/call",
+  "params": {
+    "name": "fs.download_url",
+    "arguments": {
+      "server_id": 1,
+      "path": "/var/log/syslog",
+      "ttl_seconds": 300
+    }
+  }
+}
+```
+
+The result contains:
+
+```json
+{
+  "url": "https://nezha.example.com/mcp/download/<token>",
+  "method": "GET",
+  "expires_at": "2026-05-31T19:30:00+02:00"
+}
+```
+
+Then download that URL with a regular HTTP GET client.
+
+### Upload URL
+
+Requires `nezha:server:write`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 11,
+  "method": "tools/call",
+  "params": {
+    "name": "fs.upload_url",
+    "arguments": {
+      "server_id": 1,
+      "path": "/tmp/upload.bin",
+      "ttl_seconds": 300,
+      "mode": "0644",
+      "create_dirs": true,
+      "if_match_sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    }
+  }
+}
+```
+
+The result's `method` is `POST`. Upload requests must send `Content-Length`:
+
+```shell
+curl -X POST --data-binary @upload.bin \
+  -H "Content-Length: $(wc -c < upload.bin)" \
+  "https://nezha.example.com/mcp/upload/<token>"
+```
+
+For end-to-end integrity checking, append `?sha256=<64 hex chars>` to the upload URL. The Agent checks the actual content hash after receiving the file.
+
+---
+
+## Security Tips
+
+- Create a dedicated token for MCP instead of reusing a general REST automation token.
+- Set a server ID allowlist for MCP tokens, especially tokens with `server.exec` or `server.write`.
+- Grant only the scopes needed. Do not grant write when read is enough, and do not grant `exec` when write is enough.
+- Revoke tokens when they are no longer needed.
+- Disabling `enable_mcp` immediately blocks new `/mcp` requests and revokes MCP temporary URLs, transfer streams, and in-flight MCP RPC calls.
+
+---
+
+## Related Pages
+
+- [API Interface: API Token (PAT)](/en_US/guide/api.html#api-token-pat)
+- [API Interface](/en_US/guide/api.html)
+- [Dashboard configuration: enable_mcp](/en_US/configuration/dashboard.html#enable-mcp)

--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -161,6 +161,98 @@ PAT 使用 `nezha:{resource}:{verb}` 命名权限范围。JWT 登录请求不走
 - 如果服务器启用了“对游客隐藏”，游客不能访问该服务器的数据。
 - 服务历史和服务器指标接口中，游客只能查询 `1d` 周期数据。
 
+### API Token (PAT)
+
+API Token 是同一套 `/api/v1` REST API 的另一种认证方式，也可以称为 PAT（Personal Access Token）。它和登录接口返回的 JWT 共用 `Authorization: Bearer ...` 请求头，也共用下方的接口返回格式和路由；区别是 JWT 面向浏览器登录会话，API Token 面向脚本、自动化工具和 MCP 客户端。
+
+明文 Token 统一以 `nzp_` 开头。Dashboard 只保存哈希，明文只会在创建成功后显示一次；关闭弹窗后无法再次查看，需要重新创建。
+
+登录管理前端，进入 **设置 > API Tokens**，点击 **Create API Token** 创建。创建时需要填写：
+
+| 字段 | 说明 |
+| --- | --- |
+| 名称 | 便于识别用途，例如 `homepage-readonly`、`mcp-maintenance`。最长 128 个字符。 |
+| Scopes | Token 可以调用哪些资源和动作。至少选择一个。 |
+| Server IDs | 可选的服务器 ID 白名单，使用英文逗号分隔，例如 `1,2,3`。留空表示不额外限制服务器，但仍受用户自身权限限制。 |
+| Expires in days | 可选过期天数。默认前端填入 `90`；留空或填 `0` 表示永不过期。最大 3650 天。 |
+
+普通用户可以创建、查看和吊销自己的 Token。管理员同样通过该页面管理自己的 Token，并且只有管理员可以签发 `nezha:admin:*` 或 `nezha:*` 这类管理员 scope。
+
+REST API 调用方式与 JWT 相同：
+
+```http
+Authorization: Bearer nzp_xxxxxxxxxxxxxxxxxxxx
+```
+
+API Token 使用 `nezha:{resource}:{verb}` scope 控制权限，且只会收窄当前用户原本拥有的权限；即使 Token 带有某个 scope，仍然不能越过用户本身的服务器、管理员或资源归属限制。创建 Token 时还可以填写服务器 ID 白名单，空白表示不额外限制服务器。
+
+常见错误：
+
+| 状态码 | 含义 |
+| --- | --- |
+| `401 Unauthorized` | Token 无效、已过期、所属用户不存在，或 `Authorization` 头格式错误。 |
+| `403 Forbidden` | Token 有效，但缺少当前接口需要的 scope，服务器不在白名单内，用户没有该服务器权限，或接口明确禁止 API Token 调用。 |
+
+常用 scope：
+
+| Scope | 说明 |
+| --- | --- |
+| `nezha:inventory:read` | 读取服务器清单、服务器分组和实时服务器状态流 |
+| `nezha:inventory:delete` | 删除服务器和服务器分组 |
+| `nezha:server:read` | 读取已知服务器详情、指标、服务状态和文件列表/文件内容 |
+| `nezha:server:write` | 修改服务器、下发配置、强制更新、迁移服务器和写入文件 |
+| `nezha:server:delete` | 删除服务器上的文件 |
+| `nezha:server:exec` | 打开在线终端、执行命令 |
+| `nezha:service:read/write/delete` | 读取、创建/修改、删除服务监控 |
+| `nezha:alertrule:read/write/delete` | 读取、创建/修改、删除警报规则 |
+| `nezha:cron:read/write/delete/exec` | 读取、创建/修改、删除、手动触发计划任务 |
+| `nezha:ddns:read/write/delete` | 读取、创建/修改、删除 DDNS 配置 |
+| `nezha:nat:read/write/delete` | 读取、创建/修改、删除 NAT 规则 |
+| `nezha:notification:read/write/delete` | 读取、创建/修改、删除通知方式 |
+| `nezha:notification-group:read/write/delete` | 读取、创建/修改、删除通知组 |
+| `nezha:transfer:read/write/delete` | 读取、取消/重试、删除服务器迁移记录 |
+| `nezha:<resource>:*` | 某个资源的全部动作，例如 `nezha:server:*` |
+| `nezha:admin:*` | 用户、WAF、设置、在线用户等管理员接口，仅管理员可用 |
+| `nezha:*` | 全部权限，仅管理员可用 |
+
+`inventory` 与 `server` 是两个不同的资源域：前者管“能看到和删除哪些机器清单”，后者管“对已知服务器执行运行态操作”。因此只给 `nezha:server:exec` 的 Token 可以执行指定服务器命令，但不能枚举服务器列表；需要列表时还要授予 `nezha:inventory:read`。
+
+REST 路由常见 scope 对照：
+
+| 路由 | API Token 所需 scope |
+| --- | --- |
+| `GET /api/v1/server`、`GET /api/v1/ws/server`、`GET /api/v1/server-group` | `nezha:inventory:read` |
+| `POST /api/v1/batch-delete/server`、`POST /api/v1/batch-delete/server-group` | `nezha:inventory:delete` |
+| `PATCH /api/v1/server/{id}`、`GET /api/v1/server/config/{id}`、`POST /api/v1/server/config`、`POST /api/v1/batch-move/server`、`POST /api/v1/force-update/server` | `nezha:server:write` |
+| `POST /api/v1/file`、`GET /api/v1/ws/file/{id}` | 同时需要 `nezha:server:read`、`nezha:server:write`、`nezha:server:delete` |
+| `GET /api/v1/transfer`、`GET /api/v1/ws/transfer` | `nezha:transfer:read` |
+| `POST /api/v1/transfer/{id}/cancel`、`POST /api/v1/transfer/{id}/retry` | `nezha:transfer:write` |
+| `GET/POST/PATCH/DELETE` 各资源管理接口 | 对应资源的 `read`、`write`、`delete` scope |
+| `/api/v1/user`、`/api/v1/waf`、`/api/v1/online-user`、`PATCH /api/v1/setting`、`POST /api/v1/maintenance` | `nezha:admin:*` 或 `nezha:*`，且调用用户必须是管理员 |
+
+常见授权组合：
+
+| 场景 | 建议 scope |
+| --- | --- |
+| 外部看板只读展示服务器清单 | `nezha:inventory:read` |
+| 外部看板读取服务器详情和指标 | `nezha:inventory:read`、`nezha:server:read` |
+| MCP 客户端查询服务器和读取小文件 | `nezha:inventory:read`、`nezha:server:read` |
+| MCP 客户端执行维护命令 | `nezha:inventory:read`、`nezha:server:read`、`nezha:server:exec`，并设置服务器 ID 白名单 |
+| MCP 客户端写入或上传文件 | `nezha:server:read`、`nezha:server:write`，并设置服务器 ID 白名单 |
+| CI/CD 只触发指定计划任务 | `nezha:cron:read`、`nezha:cron:exec` |
+| 运维脚本管理服务监控 | `nezha:service:read`、`nezha:service:write`，需要删除时再加 `nezha:service:delete` |
+| 管理员自动化维护设置 | `nezha:admin:*`，仅管理员 Token 可用 |
+
+如果 Token 用于单台或少量服务器，建议始终填写 `Server IDs` 白名单。这样即使 scope 较宽，也只能作用于指定服务器。
+
+旧版 `mcp:*` scope 不再作为运行时权限使用。创建 Token 时，`mcp:server:read`、`mcp:server:exec`、`mcp:fs:read` 会被兼容重写为对应的 `nezha:*` scope；`mcp:fs:write`、`mcp:fs:delete`、`mcp:*` 会被拒绝。启动迁移会清理数据库中残留的危险旧 scope，清理后没有任何 scope 的 Token 会被删除。
+
+::: warning
+API Token 不能调用账号自管理接口，例如 `/api/v1/profile`、`/api/v1/refresh-token`、`/api/v1/oauth2/{provider}/unbind` 和 `/api/v1/api-tokens`。这些接口只能使用网页登录产生的 JWT。
+:::
+
+在 **设置 > API Tokens** 列表中点击 **Revoke** 可以吊销 Token。吊销后，新请求会立即失败；使用该 Token 的长连接会被取消，包括服务器实时状态流、迁移流、在线终端、文件管理连接，以及正在执行的 MCP `tools/call`、文件上传/下载传输和临时传输 URL。
+
 ---
 
 ## MCP 接入
@@ -449,6 +541,53 @@ GET /api/v1/server/{id}/service
 
 ---
 
+## MCP 入口
+
+Dashboard 内置一个面向自动化客户端和 LLM 工具调用的 MCP (Model Context Protocol) HTTP 入口：
+
+完整的客户端配置、工具参数示例和文件传输说明，见 [MCP 使用指南](/guide/mcp.html)。
+
+```http
+POST /mcp
+Authorization: Bearer nzp_xxxxxxxxxxxxxxxxxxxx
+Content-Type: application/json
+```
+
+使用前需要在 Dashboard 配置或管理前端中启用 `enable_mcp`。该入口只接受 API Token，不接受 JWT；`GET /mcp` 和 `DELETE /mcp` 会返回 405。
+
+当前实现支持 Streamable HTTP 的 POST 请求/响应，不提供 SSE 会话。JSON-RPC 请求体最大为 8 MiB，每个 Token 默认限制约为每秒 10 次、每分钟 120 次请求。常用 JSON-RPC 方法：
+
+- `initialize`
+- `tools/list`
+- `tools/call`
+- `notifications/initialized`
+- `ping`
+
+`tools/list` 会返回每个工具的 `inputSchema` 和 `outputSchema`。`tools/call` 成功时，结构化结果放在 `structuredContent`，并在 `content[0].text` 中提供同一结果的 JSON 文本；工具报错时只返回 `isError: true` 和文本错误信息，避免严格 MCP 客户端用成功输出 schema 校验错误对象。
+
+已注册的 MCP 工具和所需 scope：
+
+| 工具 | 所需 scope |
+| --- | --- |
+| `meta.whoami` | 任意有效 API Token |
+| `server.list` | `nezha:inventory:read` |
+| `server.get` | `nezha:server:read` |
+| `server.exec` | `nezha:server:exec` |
+| `fs.list`、`fs.read`、`fs.download_url` | `nezha:server:read` |
+| `fs.write`、`fs.upload_url` | `nezha:server:write` |
+| `fs.delete` | `nezha:server:delete` |
+
+需要调用 Agent 的 MCP 工具要求目标 Agent 版本不低于 `v2.1.0`。`server.exec` 是非交互一次性命令，不分配 PTY，默认超时 30 秒，`timeout_seconds` 硬上限 300 秒；需要管道、重定向等 shell 语法时，请显式使用 `cmd: "sh"` 和 `args: ["-c", "..."]`。
+
+文件工具分为两类：
+
+- `fs.read` / `fs.write` 适合小文件或分段读取写入。`fs.read` 默认最多返回约 1 MiB，可使用 `offset`、`length` 和 `encoding: "utf8" | "base64"`。
+- `fs.download_url` / `fs.upload_url` 会签发一次性临时 URL，通过 `GET /mcp/download/{token}` 或 `POST /mcp/upload/{token}` 走 Dashboard 到 Agent 的 IOStream 传输，单文件硬上限 100 MiB，`ttl_seconds` 范围为 30 到 600 秒。上传时必须发送 `Content-Length`，可在 URL 查询参数追加 `sha256=<64位十六进制>` 做端到端校验；`fs.upload_url` 还支持 `mode`、`create_dirs`、`if_match_sha256`。
+
+MCP 调用同时受 API Token 的服务器 ID 白名单和用户原本权限限制。临时上传/下载 URL 在使用时还会重新校验 Token、scope、服务器白名单和服务器归属；Token 被撤销或关闭 `enable_mcp` 时，Dashboard 会撤销 MCP 传输流、清理临时 URL 并取消正在执行的 MCP RPC。
+
+---
+
 ## 使用案例
 
 ### 获取服务器列表
@@ -457,7 +596,7 @@ GET /api/v1/server/{id}/service
 import requests
 
 base_url = "https://nezha.example.com"
-token = "JWT_TOKEN"
+token = "JWT_TOKEN_OR_NZP_API_TOKEN"
 
 response = requests.get(
     f"{base_url}/api/v1/server",

--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -1,0 +1,422 @@
+---
+outline: deep
+---
+
+# MCP 使用指南
+
+Dashboard 内置一个 MCP (Model Context Protocol) HTTP 入口，适合把哪吒监控接入支持 MCP 的自动化客户端或大模型工具客户端。客户端可以列出服务器、读取服务器详情、执行一次性命令、读写文件，以及为大文件申请临时上传/下载 URL。
+
+MCP 功能默认关闭。使用前需要在 Dashboard 配置文件或管理前端设置中启用：
+
+```yaml
+enable_mcp: true
+```
+
+启用后，入口地址为：
+
+```http
+POST /mcp
+Authorization: Bearer nzp_xxxxxxxxxxxxxxxxxxxx
+Content-Type: application/json
+```
+
+`/mcp` 只接受 API Token，不接受网页登录 JWT。关于创建 `nzp_` Token、选择 scope 和服务器白名单，请先阅读 [API 接口：API Token (PAT)](/guide/api.html#api-token-pat)。
+
+---
+
+## 协议行为
+
+当前实现面向 MCP Streamable HTTP 的 POST 请求/响应，不提供独立 SSE 会话：
+
+- `POST /mcp`：JSON-RPC 请求入口。
+- `GET /mcp`：返回 `405 Method Not Allowed`。
+- `DELETE /mcp`：返回 `405 Method Not Allowed`。
+
+支持的 JSON-RPC 方法：
+
+| 方法 | 说明 |
+| --- | --- |
+| `initialize` | 初始化 MCP 会话，返回协议版本、能力和服务端信息。 |
+| `notifications/initialized` | 初始化完成通知；无 `id` 时返回 `202 Accepted`。 |
+| `ping` | 心跳；带 `id` 时返回空结果。 |
+| `tools/list` | 列出工具，包含每个工具的 `inputSchema` 和 `outputSchema`。 |
+| `tools/call` | 调用具体工具。 |
+
+请求体最大为 8 MiB。每个 Token 默认限流约为每秒 10 次、每分钟 120 次。超过限流时，普通 JSON-RPC 方法返回 429；`tools/call` 会以 MCP 工具错误形式返回 `isError: true`。
+
+`tools/call` 成功时，结构化结果放在 `structuredContent`，同一结果也会以 JSON 文本形式放入 `content[0].text`。工具执行失败时只返回 `isError: true` 和文本错误信息，不带成功结果 schema，避免严格 MCP 客户端误用成功 schema 校验错误对象。
+
+---
+
+## 客户端配置示例
+
+不同 MCP 客户端的配置字段可能不同。对于支持 Streamable HTTP URL 和自定义请求头的客户端，可以按以下形态配置：
+
+```json
+{
+  "mcpServers": {
+    "nezha": {
+      "url": "https://nezha.example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer nzp_xxxxxxxxxxxxxxxxxxxx"
+      }
+    }
+  }
+}
+```
+
+如果客户端要求显式声明 transport，可使用 HTTP 或 streamable-http 类型，具体字段以客户端文档为准。不要把网页登录 JWT、Cookie 或 OAuth 浏览器会话用于 `/mcp`。
+
+---
+
+## 简单使用案例
+
+下面这些是 MCP 客户端里更贴近用户的常见用法。实际使用时通常不需要手写 JSON-RPC，只要让客户端调用相应工具即可。
+
+### 查看哪些服务器在线
+
+可以直接问 MCP 客户端：“列出当前在线服务器，并查看某台服务器的状态。”客户端通常会先调用 `server.list` 找到可见服务器，再对目标服务器调用 `server.get` 读取状态、系统信息和 GeoIP 快照。Token 至少需要 `nezha:inventory:read` 和 `nezha:server:read`。
+
+### 执行一次巡检命令
+
+可以让客户端对指定服务器执行一次非交互巡检命令，例如查看磁盘、负载或某个服务状态。对应工具是 `server.exec`，需要 `nezha:server:exec`。建议给这类 Token 绑定服务器 ID 白名单，只允许操作明确授权的服务器。
+
+### 读取日志或配置文件
+
+当需要让 AI 帮忙判断 nginx、Caddy 或应用日志时，可以先用 `fs.list` 浏览目录，再用 `fs.read` 读取小日志片段或配置文件。Token 需要 `nezha:server:read`。大日志建议分段读取，避免一次返回过多内容。
+
+### 更新一个小配置文件
+
+如果要改一段小配置、写入临时脚本或生成诊断文件，可以使用 `fs.write`；如果客户端更适合先上传文件，也可以使用 `fs.upload_url`。这类操作需要 `nezha:server:write`。建议使用 `if_match_sha256` 防止覆盖已被别人修改的文件，并为 Token 设置服务器 ID 白名单。
+
+### 传输较大的文件
+
+对于日志包、备份片段或构建产物，不要把文件内容塞进 JSON-RPC 请求体。使用 `fs.download_url` 或 `fs.upload_url` 获取一次性 HTTP URL，再用普通 HTTP 客户端传输文件。单文件上限为 100 MiB，URL 只能使用一次，并会在过期、Token 被吊销或 MCP 被关闭时失效。
+
+---
+
+## 工具和权限
+
+MCP 工具同时受三层限制：
+
+1. API Token 必须有效且未过期。
+2. API Token 必须包含工具所需 scope。
+3. 目标服务器必须在 Token 的服务器 ID 白名单内，并且所属用户本身有该服务器权限。
+
+已注册工具：
+
+| 工具 | 所需 scope | 用途 |
+| --- | --- | --- |
+| `meta.whoami` | 任意有效 API Token | 返回当前用户 ID、是否管理员、Token ID、Token 名称、scope 和服务器白名单。 |
+| `server.list` | `nezha:inventory:read` | 列出当前 Token 可见服务器的精简信息。 |
+| `server.get` | `nezha:server:read` | 读取单台服务器的 Host/State/GeoIP 快照。 |
+| `server.exec` | `nezha:server:exec` | 在目标服务器执行非交互一次性命令。 |
+| `fs.list` | `nezha:server:read` | 列出目录。 |
+| `fs.read` | `nezha:server:read` | 读取文件内容，适合小文件或分段读取。 |
+| `fs.write` | `nezha:server:write` | 原子写入文件。 |
+| `fs.delete` | `nezha:server:delete` | 删除文件或目录。 |
+| `fs.download_url` | `nezha:server:read` | 签发一次性 HTTP 下载 URL，适合最多 100 MiB 的文件。 |
+| `fs.upload_url` | `nezha:server:write` | 签发一次性 HTTP 上传 URL，适合最多 100 MiB 的文件。 |
+
+需要调用 Agent 的工具要求目标 Agent 版本不低于 `v2.1.0`。Agent 上报 `2.1.0` 或 `v2.1.0` 都会被接受；低于该版本会返回不支持 MCP 的工具错误。
+
+---
+
+## 调用示例
+
+### 初始化
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2024-11-05",
+    "capabilities": {},
+    "clientInfo": {
+      "name": "my-client",
+      "version": "1.0.0"
+    }
+  }
+}
+```
+
+### 查看当前 Token
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "meta.whoami",
+    "arguments": {}
+  }
+}
+```
+
+### 列出在线服务器
+
+需要 `nezha:inventory:read`：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "tools/call",
+  "params": {
+    "name": "server.list",
+    "arguments": {
+      "online_only": true
+    }
+  }
+}
+```
+
+### 读取服务器详情
+
+需要 `nezha:server:read`：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "tools/call",
+  "params": {
+    "name": "server.get",
+    "arguments": {
+      "server_id": 1
+    }
+  }
+}
+```
+
+### 执行命令
+
+需要 `nezha:server:exec`：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "method": "tools/call",
+  "params": {
+    "name": "server.exec",
+    "arguments": {
+      "server_id": 1,
+      "cmd": "uname",
+      "args": ["-a"],
+      "timeout_seconds": 30,
+      "max_output_bytes": 65536
+    }
+  }
+}
+```
+
+`server.exec` 是非交互一次性命令：
+
+- 不分配 PTY。
+- 默认超时 30 秒。
+- `timeout_seconds` 最大 300 秒。
+- stdout/stderr 默认各最多约 64 KiB，可通过 `max_output_bytes` 调整，但 Agent 有硬上限。
+- 如果需要管道、重定向、变量展开等 shell 语法，请显式调用 shell：
+
+```json
+{
+  "server_id": 1,
+  "cmd": "sh",
+  "args": ["-c", "df -h | grep /data"],
+  "timeout_seconds": 30
+}
+```
+
+### 列目录
+
+需要 `nezha:server:read`：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 6,
+  "method": "tools/call",
+  "params": {
+    "name": "fs.list",
+    "arguments": {
+      "server_id": 1,
+      "path": "/var/log",
+      "show_hidden": false
+    }
+  }
+}
+```
+
+### 读取文件
+
+需要 `nezha:server:read`：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "method": "tools/call",
+  "params": {
+    "name": "fs.read",
+    "arguments": {
+      "server_id": 1,
+      "path": "/etc/hostname",
+      "offset": 0,
+      "length": 4096,
+      "encoding": "utf8"
+    }
+  }
+}
+```
+
+`fs.read` 适合小文件或分段读取，默认最多返回约 1 MiB。`encoding` 可选 `utf8` 或 `base64`。
+
+### 写入文件
+
+需要 `nezha:server:write`：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 8,
+  "method": "tools/call",
+  "params": {
+    "name": "fs.write",
+    "arguments": {
+      "server_id": 1,
+      "path": "/tmp/nezha-note.txt",
+      "content": "hello from nezha mcp\n",
+      "encoding": "utf8",
+      "mode": "0644",
+      "create_dirs": true
+    }
+  }
+}
+```
+
+可使用 `if_match_sha256` 做乐观锁，避免覆盖已经改变的文件。
+
+### 删除文件或目录
+
+需要 `nezha:server:delete`：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 9,
+  "method": "tools/call",
+  "params": {
+    "name": "fs.delete",
+    "arguments": {
+      "server_id": 1,
+      "path": "/tmp/nezha-note.txt",
+      "recursive": false
+    }
+  }
+}
+```
+
+删除非空目录时需要设置 `recursive: true`。
+
+---
+
+## 大文件上传和下载
+
+`fs.download_url` 和 `fs.upload_url` 会先通过 MCP 工具调用签发一次性临时 URL，再由普通 HTTP 客户端传输文件。文件内容不会进入 MCP JSON-RPC 请求体，适合较大的文件。
+
+限制和行为：
+
+- URL 默认有效期 300 秒。
+- 默认 TTL 为 300 秒；工具 schema 建议 `ttl_seconds` 使用 30 到 600 秒，服务端会把超过 600 的值截断为 600。
+- URL 只能使用一次，使用后立即失效。
+- 单个文件最大 100 MiB。
+- 传输最长 10 分钟。
+- 使用临时 URL 时会重新校验 `enable_mcp`、Token、scope、服务器白名单和用户服务器权限。
+- Token 被吊销或管理员关闭 `enable_mcp` 时，未使用 URL 和进行中的传输会被撤销。
+
+### 下载 URL
+
+需要 `nezha:server:read`：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 10,
+  "method": "tools/call",
+  "params": {
+    "name": "fs.download_url",
+    "arguments": {
+      "server_id": 1,
+      "path": "/var/log/syslog",
+      "ttl_seconds": 300
+    }
+  }
+}
+```
+
+返回结果包含：
+
+```json
+{
+  "url": "https://nezha.example.com/mcp/download/<token>",
+  "method": "GET",
+  "expires_at": "2026-05-31T19:30:00+02:00"
+}
+```
+
+随后用普通 HTTP GET 下载该 URL。
+
+### 上传 URL
+
+需要 `nezha:server:write`：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 11,
+  "method": "tools/call",
+  "params": {
+    "name": "fs.upload_url",
+    "arguments": {
+      "server_id": 1,
+      "path": "/tmp/upload.bin",
+      "ttl_seconds": 300,
+      "mode": "0644",
+      "create_dirs": true,
+      "if_match_sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    }
+  }
+}
+```
+
+返回结果中的 `method` 为 `POST`。上传时必须发送 `Content-Length`：
+
+```shell
+curl -X POST --data-binary @upload.bin \
+  -H "Content-Length: $(wc -c < upload.bin)" \
+  "https://nezha.example.com/mcp/upload/<token>"
+```
+
+如需端到端校验，可在上传 URL 后追加 `?sha256=<64位十六进制>`。Agent 会在接收后校验实际内容哈希。
+
+---
+
+## 安全建议
+
+- MCP Token 建议单独创建，不要和普通 REST 自动化共用。
+- 为 MCP Token 设置服务器 ID 白名单，尤其是带 `server.exec` 或 `server.write` 的 Token。
+- 只给需要的 scope。能读就不要给写，能写就不要给 `exec`。
+- 不再需要时及时吊销 Token。
+- 关闭 `enable_mcp` 可以立即阻断 `/mcp` 新请求，并撤销 MCP 临时 URL、传输流和正在执行的 MCP RPC。
+
+---
+
+## 相关页面
+
+- [API 接口：API Token (PAT)](/guide/api.html#api-token-pat)
+- [API 接口](/guide/api.html)
+- [Dashboard 配置：enable_mcp](/configuration/dashboard.html#enable-mcp)


### PR DESCRIPTION
## Summary
- Merge API Token (PAT) guidance into the API pages for zh-CN and en-US, including scopes, server allowlists, legacy `mcp:*` compatibility, and revoke behavior.
- Add standalone MCP guide pages with client configuration, JSON-RPC behavior, tool permissions, file transfer details, and simple user-facing use cases.
- Update dashboard configuration docs/sidebar coverage for MCP, including `enable_mcp` behavior and alignment with dashboard config fields such as `reserved_hosts` and JWT secret rotation fields.

## Verification
- `git diff --check`
- `git diff --cached --check`
- `npm run build` (passes; existing `caddy` syntax-highlight fallback warning only)